### PR TITLE
port udivmoddi4 and __aeabi_uldivmod

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,3 +2,6 @@
 authors = ["Jorge Aparicio <japaricious@gmail.com>"]
 name = "rustc_builtins"
 version = "0.1.0"
+
+[dev-dependencies]
+quickcheck = "0.3.1"

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -49,19 +49,19 @@ install_c_toolchain() {
             ;;
         mips-unknown-linux-gnu)
             apt-get install -y --no-install-recommends \
-                    gcc-mips-linux-gnu libc6-dev-mips-cross
+                    gcc gcc-mips-linux-gnu libc6-dev-mips-cross
             ;;
         mipsel-unknown-linux-gnu)
             apt-get install -y --no-install-recommends \
-                    gcc-mipsel-linux-gnu libc6-dev-mipsel-cross
+                    gcc gcc-mipsel-linux-gnu libc6-dev-mipsel-cross
             ;;
         powerpc64-unknown-linux-gnu)
             apt-get install -y --no-install-recommends \
-                    gcc-powerpc64-linux-gnu libc6-dev-ppc64-cross
+                    gcc gcc-powerpc64-linux-gnu libc6-dev-ppc64-cross
             ;;
         powerpc64le-unknown-linux-gnu)
             apt-get install -y --no-install-recommends \
-                    gcc-powerpc64le-linux-gnu libc6-dev-ppc64el-cross
+                    gcc gcc-powerpc64le-linux-gnu libc6-dev-ppc64el-cross
             ;;
     esac
 }

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -49,19 +49,19 @@ install_c_toolchain() {
             ;;
         mips-unknown-linux-gnu)
             apt-get install -y --no-install-recommends \
-                    gcc gcc-mips-linux-gnu libc6-dev-mips-cross
+                    gcc gcc-mips-linux-gnu libc6-dev libc6-dev-mips-cross
             ;;
         mipsel-unknown-linux-gnu)
             apt-get install -y --no-install-recommends \
-                    gcc gcc-mipsel-linux-gnu libc6-dev-mipsel-cross
+                    gcc gcc-mipsel-linux-gnu libc6-dev libc6-dev-mipsel-cross
             ;;
         powerpc64-unknown-linux-gnu)
             apt-get install -y --no-install-recommends \
-                    gcc gcc-powerpc64-linux-gnu libc6-dev-ppc64-cross
+                    gcc gcc-powerpc64-linux-gnu libc6-dev libc6-dev-ppc64-cross
             ;;
         powerpc64le-unknown-linux-gnu)
             apt-get install -y --no-install-recommends \
-                    gcc gcc-powerpc64le-linux-gnu libc6-dev-ppc64el-cross
+                    gcc gcc-powerpc64le-linux-gnu libc6-dev libc6-dev-ppc64el-cross
             ;;
     esac
 }

--- a/src/arm.rs
+++ b/src/arm.rs
@@ -1,3 +1,20 @@
+use core::mem;
+
+#[repr(C)]
+pub struct u64x2 {
+    a: u64,
+    b: u64,
+}
+
+#[no_mangle]
+pub unsafe extern "aapcs" fn __aeabi_uldivmod(num: u64, den: u64) -> u64x2 {
+
+    let mut rem = mem::uninitialized();
+    let quot = ::__udivmoddi4(num, den, &mut rem);
+
+    u64x2 { a: quot, b: rem }
+}
+
 extern "C" {
     fn memcpy(dest: *mut u8, src: *const u8, n: usize) -> *mut u8;
     fn memmove(dest: *mut u8, src: *const u8, n: usize) -> *mut u8;

--- a/src/arm.rs
+++ b/src/arm.rs
@@ -1,18 +1,33 @@
-use core::mem;
+use core::intrinsics;
 
-#[repr(C)]
-pub struct u64x2 {
-    a: u64,
-    b: u64,
+// TODO use `global_asm!`
+#[naked]
+#[no_mangle]
+pub unsafe extern "aapcs" fn __aeabi_uidivmod() {
+    asm!("push    { lr }
+          sub     sp, sp, #4
+          mov     r2, sp
+          bl      __udivmodsi4
+          ldr     r1, [sp]
+          add     sp, sp, #4
+          pop     { pc }");
+    intrinsics::unreachable();
 }
 
+// TODO use `global_asm!`
+#[naked]
 #[no_mangle]
-pub unsafe extern "aapcs" fn __aeabi_uldivmod(num: u64, den: u64) -> u64x2 {
-
-    let mut rem = mem::uninitialized();
-    let quot = ::__udivmoddi4(num, den, &mut rem);
-
-    u64x2 { a: quot, b: rem }
+pub unsafe extern "aapcs" fn __aeabi_uldivmod() {
+    asm!("push	{r11, lr}
+          sub	sp, sp, #16
+          add	r12, sp, #8
+          str	r12, [sp]
+          bl	__udivmoddi4
+          ldr	r2, [sp, #8]
+          ldr	r3, [sp, #12]
+          add	sp, sp, #16
+          pop	{r11, pc}");
+    intrinsics::unreachable();
 }
 
 extern "C" {

--- a/src/arm.rs
+++ b/src/arm.rs
@@ -1,5 +1,7 @@
 use core::intrinsics;
 
+// NOTE This function and the one below are implemented using assembly because they using a custom
+// calling convention which can't be implemented using a normal Rust function
 // TODO use `global_asm!`
 #[naked]
 #[no_mangle]

--- a/src/div.rs
+++ b/src/div.rs
@@ -7,7 +7,7 @@ pub extern "C" fn __udivsi3(n: u32, d: u32) -> u32 {
 
     // Special cases
     if d == 0 {
-        return 0; // ?!
+        panic!("Division by zero");
     }
 
     if n == 0 {
@@ -49,8 +49,7 @@ pub extern "C" fn __udivsi3(n: u32, d: u32) -> u32 {
         r -= d & s as u32;
     }
 
-    q = (q << 1) | carry;
-    q
+    (q << 1) | carry
 }
 
 /// Returns `n / d` and sets `*rem = n % d`
@@ -105,13 +104,7 @@ pub extern "C" fn __udivmoddi4(n: u64, d: u64, rem: Option<&mut u64>) -> u64 {
             // ---
             // 0 0
 
-            // NOTE copied verbatim from compiler-rt. This probably lets the intrinsic decide how to
-            // handle the division by zero (SIGFPE, 0, etc.). But this part shouldn't be reachable
-            // from safe code.
-            if let Some(rem) = rem {
-                *rem = u64::from(n.high() % d.low());
-            }
-            return u64::from(n.high() / d.low());
+            panic!("Division by zero");
         }
 
         // d.high() != 0

--- a/src/div.rs
+++ b/src/div.rs
@@ -1,0 +1,278 @@
+use {Int, LargeInt, U64};
+
+/// Returns `n / d`
+#[no_mangle]
+pub extern "C" fn __udivsi3(n: u32, d: u32) -> u32 {
+    let u32_bits = u32::bits() as u32;
+
+    // Special cases
+    if d == 0 {
+        return 0; // ?!
+    }
+
+    if n == 0 {
+        return 0;
+    }
+
+    let mut sr = d.leading_zeros().wrapping_sub(n.leading_zeros());
+
+    // d > n
+    if sr > u32_bits - 1 {
+        return 0;
+    }
+
+    // d == 1
+    if sr == u32_bits - 1 {
+        return n;
+    }
+
+    sr = sr + 1;
+
+    // 1 <= sr <= u32_bits - 1
+    let mut q = n << (u32_bits - sr);
+    let mut r = n >> sr;
+
+    let mut carry = 0;
+    for _ in 0..sr {
+        // r:q = ((r:q) << 1) | carry
+        r = (r << 1) | (q >> (u32_bits - 1));
+        q = (q << 1) | carry;
+
+        // carry = 0;
+        // if r > d {
+        //     r -= d;
+        //     carry = 1;
+        // }
+
+        let s = (d.wrapping_sub(r).wrapping_sub(1)) as i32 >> (u32_bits - 1);
+        carry = (s & 1) as u32;
+        r -= d & s as u32;
+    }
+
+    q = (q << 1) | carry;
+    q
+}
+
+/// Returns `n / d` and sets `*rem = n % d`
+#[no_mangle]
+pub extern "C" fn __udivmodsi4(a: u32, b: u32, rem: Option<&mut u32>) -> u32 {
+    let d = __udivsi3(a, b);
+    if let Some(rem) = rem {
+        *rem = a - (d * b);
+    }
+    return d;
+}
+
+/// Returns `n / d` and sets `*rem = n % d`
+#[no_mangle]
+pub extern "C" fn __udivmoddi4(n: u64, d: u64, rem: Option<&mut u64>) -> u64 {
+    let u32_bits = u32::bits() as u32;
+    let u64_bits = u64::bits() as u32;
+
+    // NOTE X is unknown, K != 0
+    if n.high() == 0 {
+        if d.high() == 0 {
+            // 0 X
+            // ---
+            // 0 X
+
+            if let Some(rem) = rem {
+                *rem = u64::from(n.low() % d.low());
+            }
+            return u64::from(n.low() / d.low());
+        } else
+        // d.high() != 0
+        {
+            // 0 X
+            // ---
+            // K X
+
+            if let Some(rem) = rem {
+                *rem = u64::from(n.low());
+            }
+            return 0;
+        };
+    }
+
+    let mut sr;
+    let mut q = U64 { low: 0, high: 0 };
+    let mut r = U64 { low: 0, high: 0 };
+
+    // n.high() != 0
+    if d.low() == 0 {
+        if d.high() == 0 {
+            // K X
+            // ---
+            // 0 0
+
+            // NOTE copied verbatim from compiler-rt. This probably lets the intrinsic decide how to
+            // handle the division by zero (SIGFPE, 0, etc.). But this part shouldn't be reachable
+            // from safe code.
+            if let Some(rem) = rem {
+                *rem = u64::from(n.high() % d.low());
+            }
+            return u64::from(n.high() / d.low());
+        }
+
+        // d.high() != 0
+        if n.low() == 0 {
+            // K 0
+            // ---
+            // K 0
+
+            if let Some(rem) = rem {
+                *rem = U64 {
+                    low: 0,
+                    high: n.high() % d.high(),
+                }[..];
+            }
+            return u64::from(n.high() / d.high());
+        }
+
+        // n.low() != 0
+        // K K
+        // ---
+        // K 0
+
+        if d.high().is_power_of_two() {
+            if let Some(rem) = rem {
+                *rem = U64 {
+                    low: n.low(),
+                    high: n.high() & (d.high() - 1),
+                }[..];
+            }
+
+            return u64::from(n.high() >> d.high().trailing_zeros());
+        }
+
+        sr = d.high().leading_zeros().wrapping_sub(n.high().leading_zeros());
+
+        // D > N
+        if sr > u32_bits - 2 {
+            if let Some(rem) = rem {
+                *rem = n;
+            }
+            return 0;
+        }
+
+        sr = sr + 1;
+
+        // 1 <= sr <= u32_bits - 1
+        // q = n << (u64_bits - sr);
+        q.low = 0;
+        q.high = n.low() << (u32_bits - sr);
+        // r = n >> sr
+        r.high = n.high() >> sr;
+        r.low = (n.high() << (u32_bits - sr)) | (n.low() >> sr);
+    } else
+    // d.low() != 0
+    {
+        if d.high() == 0 {
+            // K X
+            // ---
+            // 0 K
+            if d.low().is_power_of_two() {
+                if let Some(rem) = rem {
+                    *rem = u64::from(n.low() & (d.low() - 1));
+                }
+
+                if d.low() == 1 {
+                    return n;
+                } else {
+                    let sr = d.low().trailing_zeros();
+                    return U64 {
+                        low: (n.high() << (u32_bits - sr)) | (n.low() >> sr),
+                        high: n.high() >> sr,
+                    }[..];
+                };
+            }
+
+            sr = 1 + u32_bits + d.low().leading_zeros() - n.high().leading_zeros();
+
+            // 2 <= sr <= u64_bits - 1
+            // q = n << (u64_bits - sr)
+            // r = n >> sr;
+            if sr == u32_bits {
+                q.low = 0;
+                q.high = n.low();
+                r.high = 0;
+                r.low = n.high();
+            } else if sr < u32_bits
+            // 2 <= sr <= u32_bits - 1
+            {
+                q.low = 0;
+                q.high = n.low() << (u32_bits - sr);
+                r.high = n.high() >> sr;
+                r.low = (n.high() << (u32_bits - sr)) | (n.low() >> sr);
+            } else
+            // u32_bits + 1 <= sr <= u64_bits - 1
+            {
+                q.low = n.low() << (u64_bits - sr);
+                q.high = (n.high() << (u64_bits - sr)) | (n.low() >> (sr - u32_bits));
+                r.high = 0;
+                r.low = n.high() >> (sr - u32_bits);
+            }
+
+        } else
+        // d.high() != 0
+        {
+            // K X
+            // ---
+            // K K
+
+            sr = d.high().leading_zeros().wrapping_sub(n.high().leading_zeros());
+
+            // D > N
+            if sr > u32_bits - 1 {
+                if let Some(rem) = rem {
+                    *rem = n;
+                    return 0;
+                }
+            }
+
+            sr += 1;
+
+            // 1 <= sr <= u32_bits
+            // q = n << (u64_bits - sr)
+            q.low = 0;
+            if sr == u32_bits {
+                q.high = n.low();
+                r.high = 0;
+                r.low = n.high();
+            } else {
+                q.high = n.low() << (u32_bits - sr);
+                r.high = n.high() >> sr;
+                r.low = (n.high() << (u32_bits - sr)) | (n.low() >> sr);
+            }
+        }
+    }
+
+    // Not a special case
+    // q and r are initialized with
+    // q = n << (u64_bits - sr)
+    // r = n >> sr
+    // 1 <= sr <= u64_bits - 1
+    let mut carry = 0;
+
+    for _ in 0..sr {
+        // r:q = ((r:q) << 1) | carry
+        r[..] = (r[..] << 1) | (q[..] >> 63);
+        q[..] = (q[..] << 1) | carry as u64;
+
+        // carry = 0
+        // if r >= d {
+        //     r -= d;
+        //     carry = 1;
+        // }
+
+        let s = (d.wrapping_sub(r[..]).wrapping_sub(1)) as i64 >> (u64_bits - 1);
+        carry = (s & 1) as u32;
+        r[..] -= d & s as u64;
+    }
+
+    q[..] = (q[..] << 1) | carry as u64;
+    if let Some(rem) = rem {
+        *rem = r[..];
+    }
+    q[..]
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,8 +15,12 @@ extern crate quickcheck;
 #[cfg(target_arch = "arm")]
 pub mod arm;
 
+pub mod div;
+
 #[cfg(test)]
 mod test;
+
+use core::ops::{Index, IndexMut, RangeFull};
 
 /// Trait for some basic operations on integers
 trait Int {
@@ -85,6 +89,36 @@ impl LargeInt for i64 {
     }
 }
 
+/// Union-like access to the 32-bit words that make an `u64`: `x.low` and `x.high`. The whole `u64`
+/// can be accessed via the expression `x[..]`, which can be used in lvalue or rvalue position.
+#[cfg(target_endian = "little")]
+#[repr(C)]
+struct U64 {
+    low: u32,
+    high: u32,
+}
+
+#[cfg(target_endian = "big")]
+#[repr(C)]
+struct U64 {
+    high: u32,
+    low: u32,
+}
+
+impl Index<RangeFull> for U64 {
+    type Output = u64;
+
+    fn index(&self, _: RangeFull) -> &u64 {
+        unsafe { &*(self as *const _ as *const u64) }
+    }
+}
+
+impl IndexMut<RangeFull> for U64 {
+    fn index_mut(&mut self, _: RangeFull) -> &mut u64 {
+        unsafe { &mut *(self as *const _ as *mut u64) }
+    }
+}
+
 macro_rules! absv_i2 {
     ($intrinsic:ident : $ty:ty) => {
         #[no_mangle]
@@ -104,310 +138,3 @@ absv_i2!(__absvsi2: i32);
 absv_i2!(__absvdi2: i64);
 // TODO(rust-lang/35118)?
 // absv_i2!(__absvti2, i128);
-
-/// Return `n / d` and `*rem = n % d`
-#[no_mangle]
-pub extern "C" fn __udivmoddi4(n: u64, d: u64, rem: Option<&mut u64>) -> u64 {
-    use core::ops::{Index, IndexMut, RangeFull};
-
-    #[cfg(target_endian = "little")]
-    #[repr(C)]
-    struct U64 {
-        low: u32,
-        high: u32,
-    }
-
-    #[cfg(target_endian = "big")]
-    #[repr(C)]
-    struct U64 {
-        high: u32,
-        low: u32,
-    }
-
-    impl Index<RangeFull> for U64 {
-        type Output = u64;
-
-        fn index(&self, _: RangeFull) -> &u64 {
-            unsafe { &*(self as *const _ as *const u64) }
-        }
-    }
-
-    impl IndexMut<RangeFull> for U64 {
-        fn index_mut(&mut self, _: RangeFull) -> &mut u64 {
-            unsafe { &mut *(self as *const _ as *mut u64) }
-        }
-    }
-
-    let u32_bits = u32::bits() as u32;
-    let u64_bits = u64::bits() as u32;
-
-    // NOTE X is unknown, K != 0
-    if n.high() == 0 {
-        if d.high() == 0 {
-            // 0 X
-            // ---
-            // 0 X
-
-            if let Some(rem) = rem {
-                *rem = u64::from(n.low() % d.low());
-            }
-            return u64::from(n.low() / d.low());
-        } else
-        // d.high() != 0
-        {
-            // 0 X
-            // ---
-            // K X
-
-            if let Some(rem) = rem {
-                *rem = u64::from(n.low());
-            }
-            return 0;
-        };
-    }
-
-    let mut sr;
-    let mut q = U64 { low: 0, high: 0 };
-    let mut r = U64 { low: 0, high: 0 };
-
-    // n.high() != 0
-    if d.low() == 0 {
-        if d.high() == 0 {
-            // K X
-            // ---
-            // 0 0
-
-            // NOTE copied verbatim from compiler-rt. This probably lets the intrinsic decide how to
-            // handle the division by zero (SIGFPE, 0, etc.). But this part shouldn't be reachable
-            // from safe code.
-            if let Some(rem) = rem {
-                *rem = u64::from(n.high() % d.low());
-            }
-            return u64::from(n.high() / d.low());
-        }
-
-        // d.high() != 0
-        if n.low() == 0 {
-            // K 0
-            // ---
-            // K 0
-
-            if let Some(rem) = rem {
-                *rem = U64 {
-                    low: 0,
-                    high: n.high() % d.high(),
-                }[..];
-            }
-            return u64::from(n.high() / d.high());
-        }
-
-        // n.low() != 0
-        // K K
-        // ---
-        // K 0
-
-        if d.high().is_power_of_two() {
-            if let Some(rem) = rem {
-                *rem = U64 {
-                    low: n.low(),
-                    high: n.high() & (d.high() - 1),
-                }[..];
-            }
-
-            return u64::from(n.high() >> d.high().trailing_zeros());
-        }
-
-        sr = d.high().leading_zeros().wrapping_sub(n.high().leading_zeros());
-
-        // D > N
-        if sr > u32_bits - 2 {
-            if let Some(rem) = rem {
-                *rem = n;
-            }
-            return 0;
-        }
-
-        sr = sr + 1;
-
-        // 1 <= sr <= u32_bits - 1
-        // q = n << (u64_bits - sr);
-        q.low = 0;
-        q.high = n.low() << (u32_bits - sr);
-        // r = n >> sr
-        r.high = n.high() >> sr;
-        r.low = (n.high() << (u32_bits - sr)) | (n.low() >> sr);
-    } else
-    // d.low() != 0
-    {
-        if d.high() == 0 {
-            // K X
-            // ---
-            // 0 K
-            if d.low().is_power_of_two() {
-                if let Some(rem) = rem {
-                    *rem = u64::from(n.low() & (d.low() - 1));
-                }
-
-                if d.low() == 1 {
-                    return n;
-                } else {
-                    let sr = d.low().trailing_zeros();
-                    return U64 {
-                        low: (n.high() << (u32_bits - sr)) | (n.low() >> sr),
-                        high: n.high() >> sr,
-                    }[..];
-                };
-            }
-
-            sr = 1 + u32_bits + d.low().leading_zeros() - n.high().leading_zeros();
-
-            // 2 <= sr <= u64_bits - 1
-            // q = n << (u64_bits - sr)
-            // r = n >> sr;
-            if sr == u32_bits {
-                q.low = 0;
-                q.high = n.low();
-                r.high = 0;
-                r.low = n.high();
-            } else if sr < u32_bits
-            // 2 <= sr <= u32_bits - 1
-            {
-                q.low = 0;
-                q.high = n.low() << (u32_bits - sr);
-                r.high = n.high() >> sr;
-                r.low = (n.high() << (u32_bits - sr)) | (n.low() >> sr);
-            } else
-            // u32_bits + 1 <= sr <= u64_bits - 1
-            {
-                q.low = n.low() << (u64_bits - sr);
-                q.high = (n.high() << (u64_bits - sr)) | (n.low() >> (sr - u32_bits));
-                r.high = 0;
-                r.low = n.high() >> (sr - u32_bits);
-            }
-
-        } else
-        // d.high() != 0
-        {
-            // K X
-            // ---
-            // K K
-
-            sr = d.high().leading_zeros().wrapping_sub(n.high().leading_zeros());
-
-            // D > N
-            if sr > u32_bits - 1 {
-                if let Some(rem) = rem {
-                    *rem = n;
-                    return 0;
-                }
-            }
-
-            sr += 1;
-
-            // 1 <= sr <= u32_bits
-            // q = n << (u64_bits - sr)
-            q.low = 0;
-            if sr == u32_bits {
-                q.high = n.low();
-                r.high = 0;
-                r.low = n.high();
-            } else {
-                q.high = n.low() << (u32_bits - sr);
-                r.high = n.high() >> sr;
-                r.low = (n.high() << (u32_bits - sr)) | (n.low() >> sr);
-            }
-        }
-    }
-
-    // Not a special case
-    // q and r are initialized with
-    // q = n << (u64_bits - sr)
-    // r = n >> sr
-    // 1 <= sr <= u64_bits - 1
-    let mut carry = 0;
-
-    for _ in 0..sr {
-        // r:q = ((r:q) << 1) | carry
-        r[..] = (r[..] << 1) | (q[..] >> 63);
-        q[..] = (q[..] << 1) | carry as u64;
-
-        // carry = 0
-        // if r >= d {
-        //     r -= d;
-        //     carry = 1;
-        // }
-
-        let s = (d.wrapping_sub(r[..]).wrapping_sub(1)) as i64 >> (u64_bits - 1);
-        carry = (s & 1) as u32;
-        r[..] -= d & s as u64;
-    }
-
-    q[..] = (q[..] << 1) | carry as u64;
-    if let Some(rem) = rem {
-        *rem = r[..];
-    }
-    q[..]
-}
-
-/// Return `n / d` and `*rem = n % d`
-#[no_mangle]
-pub extern "C" fn __udivmodsi4(a: u32, b: u32, rem: Option<&mut u32>) -> u32 {
-    let d = __udivsi3(a, b);
-    if let Some(rem) = rem {
-        *rem = a - (d * b);
-    }
-    return d;
-}
-
-/// Return `n / d`
-#[no_mangle]
-pub extern "C" fn __udivsi3(n: u32, d: u32) -> u32 {
-    let u32_bits = u32::bits() as u32;
-
-    // Special cases
-    if d == 0 {
-        return 0; // ?!
-    }
-
-    if n == 0 {
-        return 0;
-    }
-
-    let mut sr = d.leading_zeros().wrapping_sub(n.leading_zeros());
-
-    // d > n
-    if sr > u32_bits - 1 {
-        return 0;
-    }
-
-    // d == 1
-    if sr == u32_bits - 1 {
-        return n;
-    }
-
-    sr = sr + 1;
-
-    // 1 <= sr <= u32_bits - 1
-    let mut q = n << (u32_bits - sr);
-    let mut r = n >> sr;
-
-    let mut carry = 0;
-    for _ in 0..sr {
-        // r:q = ((r:q) << 1) | carry
-        r = (r << 1) | (q >> (u32_bits - 1));
-        q = (q << 1) | carry;
-
-        // carry = 0;
-        // if r > d {
-        //     r -= d;
-        //     carry = 1;
-        // }
-
-        let s = (d.wrapping_sub(r).wrapping_sub(1)) as i32 >> (u32_bits - 1);
-        carry = (s & 1) as u32;
-        r -= d & s as u32;
-    }
-
-    q = (q << 1) | carry;
-    q
-}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,12 +8,17 @@
 
 #[cfg(test)]
 extern crate core;
+#[cfg(test)]
+#[macro_use]
+extern crate quickcheck;
 
 #[cfg(target_arch = "arm")]
 pub mod arm;
 
 #[cfg(test)]
 mod test;
+
+use core::mem;
 
 /// Trait for some basic operations on integers
 trait Int {
@@ -93,3 +98,257 @@ absv_i2!(__absvsi2: i32);
 absv_i2!(__absvdi2: i64);
 // TODO(rust-lang/35118)?
 // absv_i2!(__absvti2, i128);
+
+#[no_mangle]
+pub extern "C" fn __udivmoddi4(a: u64, b: u64, rem: *mut u64) -> u64 {
+    #[cfg(target_endian = "little")]
+    #[repr(C)]
+    #[derive(Debug)]
+    struct words {
+        low: u32,
+        high: u32,
+    }
+
+    #[cfg(target_endian = "big")]
+    #[repr(C)]
+    #[derive(Debug)]
+    struct words {
+        high: u32,
+        low: u32,
+    }
+
+    impl words {
+        fn all(&mut self) -> &mut u64 {
+            unsafe { mem::transmute(self) }
+        }
+
+        fn u64(&self) -> u64 {
+            unsafe { *(self as *const _ as *const u64) }
+        }
+    }
+
+    impl From<u64> for words {
+        fn from(x: u64) -> words {
+            unsafe { mem::transmute(x) }
+        }
+    }
+
+    let u32_bits = u32::bits() as u32;
+    let u64_bits = u64::bits() as u32;
+
+    let n = words::from(a);
+    let d = words::from(b);
+
+    // NOTE X is unknown, K != 0
+    if n.high == 0 {
+        return if d.high == 0 {
+            // 0 X
+            // ---
+            // 0 X
+
+            if let Some(rem) = unsafe { rem.as_mut() } {
+                *rem = u64::from(n.low % d.low);
+            }
+            u64::from(n.low / d.low)
+        } else
+               // d.high != 0
+               {
+            // 0 X
+            // ---
+            // K X
+
+            if let Some(rem) = unsafe { rem.as_mut() } {
+                *rem = u64::from(n.low);
+            }
+            0
+        };
+    }
+
+    let mut sr;
+    // NOTE IMO it should be possible to leave these "uninitialized" (just declare them here)
+    // because these variables get initialized below, but if I do that the compiler complains about
+    // them being used before being initialized.
+    let mut q = words { low: 0, high: 0 };
+    let mut r = words { low: 0, high: 0 };
+
+    // n.high != 0
+    if d.low == 0 {
+        if d.high == 0 {
+            // K X
+            // ---
+            // 0 0
+
+            // NOTE copied verbatim from compiler-rt, but does division by zero even make sense?
+            if let Some(rem) = unsafe { rem.as_mut() } {
+                *rem = u64::from(n.high % d.low);
+            }
+            return u64::from(n.high / d.low);
+        }
+
+        // d.high != 0
+        if n.low == 0 {
+            // K 0
+            // ---
+            // K 0
+
+            if let Some(rem) = unsafe { rem.as_mut() } {
+                *rem = words {
+                        low: 0,
+                        high: n.high % d.high,
+                    }
+                    .u64();
+            }
+            return u64::from(n.high / d.high);
+        }
+
+        // n.low != 0
+        // K K
+        // ---
+        // K 0
+
+        if d.high.is_power_of_two() {
+            if let Some(rem) = unsafe { rem.as_mut() } {
+                *rem = words {
+                        low: n.low,
+                        high: n.high & (d.high - 1),
+                    }
+                    .u64()
+            }
+
+            return u64::from(n.high >> d.high.trailing_zeros());
+        }
+
+        sr = d.high.leading_zeros().wrapping_sub(n.high.leading_zeros());
+
+        // D > N
+        if sr > u32_bits - 2 {
+            if let Some(rem) = unsafe { rem.as_mut() } {
+                *rem = n.u64();
+            }
+            return 0;
+        }
+
+        sr = sr + 1;
+
+        // 1 <= sr <= u32_bits - 1
+        // *q.all() = n.u64() << (u64_bits - sr);
+        q.low = 0;
+        q.high = n.low << (u32_bits - sr);
+        // *r.all() = n.u64() >> sr
+        r.high = n.high >> sr;
+        r.low = (n.high << (u32_bits - sr)) | (n.low >> sr);
+    } else
+    // d.low != 0
+    {
+        if d.high == 0 {
+            // K X
+            // ---
+            // 0 K
+            if d.low.is_power_of_two() {
+                if let Some(rem) = unsafe { rem.as_mut() } {
+                    *rem = u64::from(n.low & (d.low - 1));
+                }
+
+                return if d.low == 1 {
+                    n.u64()
+                } else {
+                    let sr = d.low.trailing_zeros();
+                    words {
+                            low: (n.high << (u32_bits - sr)) | (n.low >> sr),
+                            high: n.high >> sr,
+                        }
+                        .u64()
+                };
+            }
+
+            sr = 1 + u32_bits + d.low.leading_zeros() - n.high.leading_zeros();
+
+            // 2 <= sr <= u64_bits - 1
+            // *q.all() = n.u64() << (u64_bits - sr)
+            // *r.all() = n.u64() >> sr;
+            if sr == u32_bits {
+                q.low = 0;
+                q.high = n.low;
+                r.high = 0;
+                r.low = n.high;
+            } else if sr < u32_bits
+            // 2 <= sr <= u32_bits - 1
+            {
+                q.low = 0;
+                q.high = n.low << (u32_bits - sr);
+                r.high = n.high >> sr;
+                r.low = (n.high << (u32_bits - sr)) | (n.low >> sr);
+            } else
+            // u32_bits + 1 <= sr <= u64_bits - 1
+            {
+                q.low = n.low << (u64_bits - sr);
+                q.high = (n.high << (u64_bits - sr)) | (n.low >> (sr - u32_bits));
+                r.high = 0;
+                r.low = n.high >> (sr - u32_bits);
+            }
+
+        } else
+        // d.high != 0
+        {
+            // K X
+            // ---
+            // K K
+
+            sr = d.high.leading_zeros().wrapping_sub(n.high.leading_zeros());
+
+            // D > N
+            if sr > u32_bits - 1 {
+                if let Some(rem) = unsafe { rem.as_mut() } {
+                    *rem = a;
+                    return 0;
+                }
+            }
+
+            sr += 1;
+
+            // 1 <= sr <= u32_bits
+            // *q.all() = n.u64() << (u64_bits - sr)
+            q.low = 0;
+            if sr == u32_bits {
+                q.high = n.low;
+                r.high = 0;
+                r.low = n.high;
+            } else {
+                q.high = n.low << (u32_bits - sr);
+                r.high = n.high >> sr;
+                r.low = (n.high << (u32_bits - sr)) | (n.low >> sr);
+            }
+        }
+    }
+
+    // Not a special case
+    // q and r are initialized with
+    // *q.all() = n.u64() << (u64_bits - sr)
+    // *.r.all() = n.u64() >> sr
+    // 1 <= sr <= u64_bits - 1
+    let mut carry = 0;
+
+    for _ in 0..sr {
+        // r:q = ((r:q) << 1) | carry
+        r.high = (r.high << 1) | (r.low >> (u32_bits - 1));
+        r.low = (r.low << 1) | (q.high >> (u32_bits - 1));
+        q.high = (q.high << 1) | (q.low >> (u32_bits - 1));
+        q.low = (q.low << 1) | carry;
+
+        // carry = 0
+        // if r.u64() >= d.u64() {
+        //     *r.all() -= d.u64();
+        //     carry = 1;
+        // }
+
+        let s = (d.u64().wrapping_sub(r.u64()).wrapping_sub(1)) as i64 >> (u64_bits - 1);
+        carry = (s & 1) as u32;
+        *r.all() -= d.u64() & s as u64;
+    }
+
+    *q.all() = (q.u64() << 1) | carry as u64;
+    if let Some(rem) = unsafe { rem.as_mut() } {
+        *rem = r.u64();
+    }
+    q.u64()
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -141,7 +141,7 @@ pub extern "C" fn __udivmoddi4(a: u64, b: u64, rem: Option<&mut u64>) -> u64 {
 
     // NOTE X is unknown, K != 0
     if n.high == 0 {
-        return if d.high == 0 {
+        if d.high == 0 {
             // 0 X
             // ---
             // 0 X
@@ -149,7 +149,7 @@ pub extern "C" fn __udivmoddi4(a: u64, b: u64, rem: Option<&mut u64>) -> u64 {
             if let Some(rem) = rem {
                 *rem = u64::from(n.low % d.low);
             }
-            u64::from(n.low / d.low)
+            return u64::from(n.low / d.low);
         } else
                // d.high != 0
                {
@@ -160,7 +160,7 @@ pub extern "C" fn __udivmoddi4(a: u64, b: u64, rem: Option<&mut u64>) -> u64 {
             if let Some(rem) = rem {
                 *rem = u64::from(n.low);
             }
-            0
+            return 0;
         };
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,7 +100,7 @@ absv_i2!(__absvdi2: i64);
 // absv_i2!(__absvti2, i128);
 
 #[no_mangle]
-pub extern "C" fn __udivmoddi4(a: u64, b: u64, rem: *mut u64) -> u64 {
+pub extern "C" fn __udivmoddi4(a: u64, b: u64, rem: Option<&mut u64>) -> u64 {
     #[cfg(target_endian = "little")]
     #[repr(C)]
     #[derive(Debug)]
@@ -146,7 +146,7 @@ pub extern "C" fn __udivmoddi4(a: u64, b: u64, rem: *mut u64) -> u64 {
             // ---
             // 0 X
 
-            if let Some(rem) = unsafe { rem.as_mut() } {
+            if let Some(rem) = rem {
                 *rem = u64::from(n.low % d.low);
             }
             u64::from(n.low / d.low)
@@ -157,7 +157,7 @@ pub extern "C" fn __udivmoddi4(a: u64, b: u64, rem: *mut u64) -> u64 {
             // ---
             // K X
 
-            if let Some(rem) = unsafe { rem.as_mut() } {
+            if let Some(rem) = rem {
                 *rem = u64::from(n.low);
             }
             0
@@ -179,7 +179,7 @@ pub extern "C" fn __udivmoddi4(a: u64, b: u64, rem: *mut u64) -> u64 {
             // 0 0
 
             // NOTE copied verbatim from compiler-rt, but does division by zero even make sense?
-            if let Some(rem) = unsafe { rem.as_mut() } {
+            if let Some(rem) = rem {
                 *rem = u64::from(n.high % d.low);
             }
             return u64::from(n.high / d.low);
@@ -191,7 +191,7 @@ pub extern "C" fn __udivmoddi4(a: u64, b: u64, rem: *mut u64) -> u64 {
             // ---
             // K 0
 
-            if let Some(rem) = unsafe { rem.as_mut() } {
+            if let Some(rem) = rem {
                 *rem = words {
                         low: 0,
                         high: n.high % d.high,
@@ -207,7 +207,7 @@ pub extern "C" fn __udivmoddi4(a: u64, b: u64, rem: *mut u64) -> u64 {
         // K 0
 
         if d.high.is_power_of_two() {
-            if let Some(rem) = unsafe { rem.as_mut() } {
+            if let Some(rem) = rem {
                 *rem = words {
                         low: n.low,
                         high: n.high & (d.high - 1),
@@ -222,7 +222,7 @@ pub extern "C" fn __udivmoddi4(a: u64, b: u64, rem: *mut u64) -> u64 {
 
         // D > N
         if sr > u32_bits - 2 {
-            if let Some(rem) = unsafe { rem.as_mut() } {
+            if let Some(rem) = rem {
                 *rem = n.u64();
             }
             return 0;
@@ -245,7 +245,7 @@ pub extern "C" fn __udivmoddi4(a: u64, b: u64, rem: *mut u64) -> u64 {
             // ---
             // 0 K
             if d.low.is_power_of_two() {
-                if let Some(rem) = unsafe { rem.as_mut() } {
+                if let Some(rem) = rem {
                     *rem = u64::from(n.low & (d.low - 1));
                 }
 
@@ -298,7 +298,7 @@ pub extern "C" fn __udivmoddi4(a: u64, b: u64, rem: *mut u64) -> u64 {
 
             // D > N
             if sr > u32_bits - 1 {
-                if let Some(rem) = unsafe { rem.as_mut() } {
+                if let Some(rem) = rem {
                     *rem = a;
                     return 0;
                 }
@@ -347,16 +347,16 @@ pub extern "C" fn __udivmoddi4(a: u64, b: u64, rem: *mut u64) -> u64 {
     }
 
     *q.all() = (q.u64() << 1) | carry as u64;
-    if let Some(rem) = unsafe { rem.as_mut() } {
+    if let Some(rem) = rem {
         *rem = r.u64();
     }
     q.u64()
 }
 
 #[no_mangle]
-pub extern "C" fn __udivmodsi4(a: u32, b: u32, rem: *mut u32) -> u32 {
+pub extern "C" fn __udivmodsi4(a: u32, b: u32, rem: Option<&mut u32>) -> u32 {
     let d = __udivsi3(a, b);
-    if let Some(rem) = unsafe {rem.as_mut()} {
+    if let Some(rem) = rem {
         *rem = a - (d*b);
     }
     return d;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,8 +18,6 @@ pub mod arm;
 #[cfg(test)]
 mod test;
 
-use core::mem;
-
 /// Trait for some basic operations on integers
 trait Int {
     fn bits() -> usize;
@@ -27,16 +25,24 @@ trait Int {
 
 // TODO: Once i128/u128 support lands, we'll want to add impls for those as well
 impl Int for u32 {
-    fn bits() -> usize { 32 }
+    fn bits() -> usize {
+        32
+    }
 }
 impl Int for i32 {
-    fn bits() -> usize { 32 }
+    fn bits() -> usize {
+        32
+    }
 }
 impl Int for u64 {
-    fn bits() -> usize { 64 }
+    fn bits() -> usize {
+        64
+    }
 }
 impl Int for i64 {
-    fn bits() -> usize { 64 }
+    fn bits() -> usize {
+        64
+    }
 }
 
 /// Trait to convert an integer to/from smaller parts
@@ -99,131 +105,124 @@ absv_i2!(__absvdi2: i64);
 // TODO(rust-lang/35118)?
 // absv_i2!(__absvti2, i128);
 
+/// Return `n / d` and `*rem = n % d`
 #[no_mangle]
-pub extern "C" fn __udivmoddi4(a: u64, b: u64, rem: Option<&mut u64>) -> u64 {
+pub extern "C" fn __udivmoddi4(n: u64, d: u64, rem: Option<&mut u64>) -> u64 {
+    use core::ops::{Index, IndexMut, RangeFull};
+
     #[cfg(target_endian = "little")]
     #[repr(C)]
-    #[derive(Debug)]
-    struct words {
+    struct U64 {
         low: u32,
         high: u32,
     }
 
     #[cfg(target_endian = "big")]
     #[repr(C)]
-    #[derive(Debug)]
-    struct words {
+    struct U64 {
         high: u32,
         low: u32,
     }
 
-    impl words {
-        fn all(&mut self) -> &mut u64 {
-            unsafe { mem::transmute(self) }
-        }
+    impl Index<RangeFull> for U64 {
+        type Output = u64;
 
-        fn u64(&self) -> u64 {
-            unsafe { *(self as *const _ as *const u64) }
+        fn index(&self, _: RangeFull) -> &u64 {
+            unsafe { &*(self as *const _ as *const u64) }
         }
     }
 
-    impl From<u64> for words {
-        fn from(x: u64) -> words {
-            unsafe { mem::transmute(x) }
+    impl IndexMut<RangeFull> for U64 {
+        fn index_mut(&mut self, _: RangeFull) -> &mut u64 {
+            unsafe { &mut *(self as *const _ as *mut u64) }
         }
     }
 
     let u32_bits = u32::bits() as u32;
     let u64_bits = u64::bits() as u32;
 
-    let n = words::from(a);
-    let d = words::from(b);
-
     // NOTE X is unknown, K != 0
-    if n.high == 0 {
-        if d.high == 0 {
+    if n.high() == 0 {
+        if d.high() == 0 {
             // 0 X
             // ---
             // 0 X
 
             if let Some(rem) = rem {
-                *rem = u64::from(n.low % d.low);
+                *rem = u64::from(n.low() % d.low());
             }
-            return u64::from(n.low / d.low);
+            return u64::from(n.low() / d.low());
         } else
-               // d.high != 0
-               {
+        // d.high() != 0
+        {
             // 0 X
             // ---
             // K X
 
             if let Some(rem) = rem {
-                *rem = u64::from(n.low);
+                *rem = u64::from(n.low());
             }
             return 0;
         };
     }
 
     let mut sr;
-    // NOTE IMO it should be possible to leave these "uninitialized" (just declare them here)
-    // because these variables get initialized below, but if I do that the compiler complains about
-    // them being used before being initialized.
-    let mut q = words { low: 0, high: 0 };
-    let mut r = words { low: 0, high: 0 };
+    let mut q = U64 { low: 0, high: 0 };
+    let mut r = U64 { low: 0, high: 0 };
 
-    // n.high != 0
-    if d.low == 0 {
-        if d.high == 0 {
+    // n.high() != 0
+    if d.low() == 0 {
+        if d.high() == 0 {
             // K X
             // ---
             // 0 0
 
-            // NOTE copied verbatim from compiler-rt, but does division by zero even make sense?
+            // NOTE copied verbatim from compiler-rt. This probably lets the intrinsic decide how to
+            // handle the division by zero (SIGFPE, 0, etc.). But this part shouldn't be reachable
+            // from safe code.
             if let Some(rem) = rem {
-                *rem = u64::from(n.high % d.low);
+                *rem = u64::from(n.high() % d.low());
             }
-            return u64::from(n.high / d.low);
+            return u64::from(n.high() / d.low());
         }
 
-        // d.high != 0
-        if n.low == 0 {
+        // d.high() != 0
+        if n.low() == 0 {
             // K 0
             // ---
             // K 0
 
             if let Some(rem) = rem {
-                *rem = words {
-                        low: 0,
-                        high: n.high % d.high,
-                    }
-                    .u64();
+                *rem = U64 {
+                    low: 0,
+                    high: n.high() % d.high(),
+                }[..];
             }
-            return u64::from(n.high / d.high);
+            return u64::from(n.high() / d.high());
         }
 
-        // n.low != 0
+        // n.low() != 0
         // K K
         // ---
         // K 0
 
-        if d.high.is_power_of_two() {
+        if d.high().is_power_of_two() {
             if let Some(rem) = rem {
-                *rem = words {
-                        low: n.low,
-                        high: n.high & (d.high - 1),
-                    }
-                    .u64()
+                *rem = U64 {
+                    low: n.low(),
+                    high: n.high() & (d.high() - 1),
+                }[..];
             }
 
-            return u64::from(n.high >> d.high.trailing_zeros());
+            return u64::from(n.high() >> d.high().trailing_zeros());
         }
 
-        sr = d.high.leading_zeros().wrapping_sub(n.high.leading_zeros());
+        sr = d.high().leading_zeros().wrapping_sub(n.high().leading_zeros());
 
         // D > N
         if sr > u32_bits - 2 {
             if let Some(rem) = rem {
-                *rem = n.u64();
+                *rem = n;
             }
             return 0;
         }
@@ -231,75 +230,74 @@ pub extern "C" fn __udivmoddi4(a: u64, b: u64, rem: Option<&mut u64>) -> u64 {
         sr = sr + 1;
 
         // 1 <= sr <= u32_bits - 1
-        // *q.all() = n.u64() << (u64_bits - sr);
+        // q = n << (u64_bits - sr);
         q.low = 0;
-        q.high = n.low << (u32_bits - sr);
-        // *r.all() = n.u64() >> sr
-        r.high = n.high >> sr;
-        r.low = (n.high << (u32_bits - sr)) | (n.low >> sr);
+        q.high = n.low() << (u32_bits - sr);
+        // r = n >> sr
+        r.high = n.high() >> sr;
+        r.low = (n.high() << (u32_bits - sr)) | (n.low() >> sr);
     } else
-    // d.low != 0
+    // d.low() != 0
     {
-        if d.high == 0 {
+        if d.high() == 0 {
             // K X
             // ---
             // 0 K
-            if d.low.is_power_of_two() {
+            if d.low().is_power_of_two() {
                 if let Some(rem) = rem {
-                    *rem = u64::from(n.low & (d.low - 1));
+                    *rem = u64::from(n.low() & (d.low() - 1));
                 }
 
-                return if d.low == 1 {
-                    n.u64()
+                if d.low() == 1 {
+                    return n;
                 } else {
-                    let sr = d.low.trailing_zeros();
-                    words {
-                            low: (n.high << (u32_bits - sr)) | (n.low >> sr),
-                            high: n.high >> sr,
-                        }
-                        .u64()
+                    let sr = d.low().trailing_zeros();
+                    return U64 {
+                        low: (n.high() << (u32_bits - sr)) | (n.low() >> sr),
+                        high: n.high() >> sr,
+                    }[..];
                 };
             }
 
-            sr = 1 + u32_bits + d.low.leading_zeros() - n.high.leading_zeros();
+            sr = 1 + u32_bits + d.low().leading_zeros() - n.high().leading_zeros();
 
             // 2 <= sr <= u64_bits - 1
-            // *q.all() = n.u64() << (u64_bits - sr)
-            // *r.all() = n.u64() >> sr;
+            // q = n << (u64_bits - sr)
+            // r = n >> sr;
             if sr == u32_bits {
                 q.low = 0;
-                q.high = n.low;
+                q.high = n.low();
                 r.high = 0;
-                r.low = n.high;
+                r.low = n.high();
             } else if sr < u32_bits
             // 2 <= sr <= u32_bits - 1
             {
                 q.low = 0;
-                q.high = n.low << (u32_bits - sr);
-                r.high = n.high >> sr;
-                r.low = (n.high << (u32_bits - sr)) | (n.low >> sr);
+                q.high = n.low() << (u32_bits - sr);
+                r.high = n.high() >> sr;
+                r.low = (n.high() << (u32_bits - sr)) | (n.low() >> sr);
             } else
             // u32_bits + 1 <= sr <= u64_bits - 1
             {
-                q.low = n.low << (u64_bits - sr);
-                q.high = (n.high << (u64_bits - sr)) | (n.low >> (sr - u32_bits));
+                q.low = n.low() << (u64_bits - sr);
+                q.high = (n.high() << (u64_bits - sr)) | (n.low() >> (sr - u32_bits));
                 r.high = 0;
-                r.low = n.high >> (sr - u32_bits);
+                r.low = n.high() >> (sr - u32_bits);
             }
 
         } else
-        // d.high != 0
+        // d.high() != 0
         {
             // K X
             // ---
             // K K
 
-            sr = d.high.leading_zeros().wrapping_sub(n.high.leading_zeros());
+            sr = d.high().leading_zeros().wrapping_sub(n.high().leading_zeros());
 
             // D > N
             if sr > u32_bits - 1 {
                 if let Some(rem) = rem {
-                    *rem = a;
+                    *rem = n;
                     return 0;
                 }
             }
@@ -307,61 +305,61 @@ pub extern "C" fn __udivmoddi4(a: u64, b: u64, rem: Option<&mut u64>) -> u64 {
             sr += 1;
 
             // 1 <= sr <= u32_bits
-            // *q.all() = n.u64() << (u64_bits - sr)
+            // q = n << (u64_bits - sr)
             q.low = 0;
             if sr == u32_bits {
-                q.high = n.low;
+                q.high = n.low();
                 r.high = 0;
-                r.low = n.high;
+                r.low = n.high();
             } else {
-                q.high = n.low << (u32_bits - sr);
-                r.high = n.high >> sr;
-                r.low = (n.high << (u32_bits - sr)) | (n.low >> sr);
+                q.high = n.low() << (u32_bits - sr);
+                r.high = n.high() >> sr;
+                r.low = (n.high() << (u32_bits - sr)) | (n.low() >> sr);
             }
         }
     }
 
     // Not a special case
     // q and r are initialized with
-    // *q.all() = n.u64() << (u64_bits - sr)
-    // *.r.all() = n.u64() >> sr
+    // q = n << (u64_bits - sr)
+    // r = n >> sr
     // 1 <= sr <= u64_bits - 1
     let mut carry = 0;
 
     for _ in 0..sr {
         // r:q = ((r:q) << 1) | carry
-        r.high = (r.high << 1) | (r.low >> (u32_bits - 1));
-        r.low = (r.low << 1) | (q.high >> (u32_bits - 1));
-        q.high = (q.high << 1) | (q.low >> (u32_bits - 1));
-        q.low = (q.low << 1) | carry;
+        r[..] = (r[..] << 1) | (q[..] >> 63);
+        q[..] = (q[..] << 1) | carry as u64;
 
         // carry = 0
-        // if r.u64() >= d.u64() {
-        //     *r.all() -= d.u64();
+        // if r >= d {
+        //     r -= d;
         //     carry = 1;
         // }
 
-        let s = (d.u64().wrapping_sub(r.u64()).wrapping_sub(1)) as i64 >> (u64_bits - 1);
+        let s = (d.wrapping_sub(r[..]).wrapping_sub(1)) as i64 >> (u64_bits - 1);
         carry = (s & 1) as u32;
-        *r.all() -= d.u64() & s as u64;
+        r[..] -= d & s as u64;
     }
 
-    *q.all() = (q.u64() << 1) | carry as u64;
+    q[..] = (q[..] << 1) | carry as u64;
     if let Some(rem) = rem {
-        *rem = r.u64();
+        *rem = r[..];
     }
-    q.u64()
+    q[..]
 }
 
+/// Return `n / d` and `*rem = n % d`
 #[no_mangle]
 pub extern "C" fn __udivmodsi4(a: u32, b: u32, rem: Option<&mut u32>) -> u32 {
     let d = __udivsi3(a, b);
     if let Some(rem) = rem {
-        *rem = a - (d*b);
+        *rem = a - (d * b);
     }
     return d;
 }
 
+/// Return `n / d`
 #[no_mangle]
 pub extern "C" fn __udivsi3(n: u32, d: u32) -> u32 {
     let u32_bits = u32::bits() as u32;

--- a/src/test.rs
+++ b/src/test.rs
@@ -42,3 +42,16 @@ quickcheck! {
         }
     }
 }
+
+quickcheck! {
+    fn udivmodsi4(a: u32, b: u32) -> TestResult {
+        if b == 0 {
+            TestResult::discard()
+        } else {
+            let mut r = 0;
+            let q = ::__udivmodsi4(a, b, &mut r);
+
+            TestResult::from_bool(q * b + r == a)
+        }
+    }
+}

--- a/src/test.rs
+++ b/src/test.rs
@@ -36,7 +36,7 @@ quickcheck! {
             TestResult::discard()
         } else {
             let mut r = 0;
-            let q = ::__udivmoddi4(a, b, Some(&mut r));
+            let q = ::div::__udivmoddi4(a, b, Some(&mut r));
 
             TestResult::from_bool(q * b + r == a)
         }
@@ -49,7 +49,7 @@ quickcheck! {
             TestResult::discard()
         } else {
             let mut r = 0;
-            let q = ::__udivmodsi4(a, b, Some(&mut r));
+            let q = ::div::__udivmodsi4(a, b, Some(&mut r));
 
             TestResult::from_bool(q * b + r == a)
         }

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,4 +1,4 @@
-use std::{mem, panic};
+use std::panic;
 
 use quickcheck::TestResult;
 
@@ -27,31 +27,30 @@ absv_i2!(__absvdi2: i64);
 // absv_i2!(__absvti2: i128);
 
 quickcheck! {
-    fn udivmoddi4(a: (u32, u32), b: (u32, u32)) -> TestResult {
-        let (a, b) = unsafe {
-            (mem::transmute(a), mem::transmute(b))
-        };
+    fn udivmoddi4(n: (u32, u32), d: (u32, u32)) -> TestResult {
+        let n = ::U64 { low: n.0, high: n.1 }[..];
+        let d = ::U64 { low: d.0, high: d.1 }[..];
 
-        if b == 0 {
+        if d == 0 {
             TestResult::discard()
         } else {
             let mut r = 0;
-            let q = ::div::__udivmoddi4(a, b, Some(&mut r));
+            let q = ::div::__udivmoddi4(n, d, Some(&mut r));
 
-            TestResult::from_bool(q * b + r == a)
+            TestResult::from_bool(q * d + r == n)
         }
     }
 }
 
 quickcheck! {
-    fn udivmodsi4(a: u32, b: u32) -> TestResult {
-        if b == 0 {
+    fn udivmodsi4(n: u32, d: u32) -> TestResult {
+        if d == 0 {
             TestResult::discard()
         } else {
             let mut r = 0;
-            let q = ::div::__udivmodsi4(a, b, Some(&mut r));
+            let q = ::div::__udivmodsi4(n, d, Some(&mut r));
 
-            TestResult::from_bool(q * b + r == a)
+            TestResult::from_bool(q * d + r == n)
         }
     }
 }

--- a/src/test.rs
+++ b/src/test.rs
@@ -36,7 +36,7 @@ quickcheck! {
             TestResult::discard()
         } else {
             let mut r = 0;
-            let q = ::__udivmoddi4(a, b, &mut r);
+            let q = ::__udivmoddi4(a, b, Some(&mut r));
 
             TestResult::from_bool(q * b + r == a)
         }
@@ -49,7 +49,7 @@ quickcheck! {
             TestResult::discard()
         } else {
             let mut r = 0;
-            let q = ::__udivmodsi4(a, b, &mut r);
+            let q = ::__udivmodsi4(a, b, Some(&mut r));
 
             TestResult::from_bool(q * b + r == a)
         }

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,4 +1,6 @@
-use std::panic;
+use std::{mem, panic};
+
+use quickcheck::TestResult;
 
 macro_rules! absv_i2 {
     ($intrinsic:ident: $ty:ident) => {
@@ -23,3 +25,20 @@ absv_i2!(__absvsi2: i32);
 absv_i2!(__absvdi2: i64);
 // TODO(rust-lang/35118)?
 // absv_i2!(__absvti2: i128);
+
+quickcheck! {
+    fn udivmoddi4(a: (u32, u32), b: (u32, u32)) -> TestResult {
+        let (a, b) = unsafe {
+            (mem::transmute(a), mem::transmute(b))
+        };
+
+        if b == 0 {
+            TestResult::discard()
+        } else {
+            let mut r = 0;
+            let q = ::__udivmoddi4(a, b, &mut r);
+
+            TestResult::from_bool(q * b + r == a)
+        }
+    }
+}


### PR DESCRIPTION
cc @thejpster

The `udivmoddi4` intrinsic is tested using quickcheck.

I'm concerned about the `__aeabi_uldivmod` intrinsic. First, I get infinite recursion but that probably can be fixed with the hacks @Amanieu suggested in #16. The other issue is that the assembly of the `__aeabi*` intrinsic doesn't look like compiler-rt's assembly implementation.

This is the assembly generated by this crate (for the `arm-unknown-linux-gnueabi` target):

``` asm
00000000 <__aeabi_uldivmod>:
   0:   e92d4010        push    {r4, lr}
   4:   e24dd010        sub     sp, sp, #16
   8:   e59dc018        ldr     ip, [sp, #24]
   c:   e59de01c        ldr     lr, [sp, #28]
  10:   e1a04000        mov     r4, r0
  14:   e28d0008        add     r0, sp, #8
  18:   e1a01003        mov     r1, r3
  1c:   e58d0000        str     r0, [sp]
  20:   e1a00002        mov     r0, r2
  24:   e1a0200c        mov     r2, ip
  28:   e1a0300e        mov     r3, lr
  2c:   ebfffffe        bl      0 <__aeabi_uldivmod>
  30:   e59d2008        ldr     r2, [sp, #8]
  34:   e59d300c        ldr     r3, [sp, #12]
  38:   e884000f        stm     r4, {r0, r1, r2, r3}
  3c:   e28dd010        add     sp, sp, #16
  40:   e8bd8010        pop     {r4, pc}
```

And this is compiler-rt's implementation:

``` asm
        push    {r11, lr}
        sub     sp, sp, #16
        add     r12, sp, #8
        str     r12, [sp]
        bl      SYMBOL_NAME(__divmoddi4)
        ldr     r2, [sp, #8]
        ldr     r3, [sp, #12]
        add     sp, sp, #16
        pop     {r11, pc}
```

Even though I implemented the intrinsic in Rust following the compiler-rt's "C implementation", which is written in the comments of the source file:

``` c
struct { int64_t quot, int64_t rem}
       __aeabi_ldivmod(int64_t numerator, int64_t denominator) {
  int64_t rem, quot;
  quot = __divmoddi4(numerator, denominator, &rem);
  return {quot, rem};
}
```

But I used `u64` because `i64` doesn't really make sense (the `__divmoddi4` takes unsigned integers as arguments).

@Amanieu Any idea of what's wrong with my `__aeabi_uldivmod` implementation? Should I implement it using assembly + naked functions instead?