### PR TITLE
Use link_args to alias arm builtins

### DIFF
--- a/src/arm.rs
+++ b/src/arm.rs
@@ -37,6 +37,7 @@ extern "C" {
 }
 
 // Create aliases for the *4 and *8 variants
+#[cfg(not(test))]
 #[link_args = "-Wl,--defsym=__aeabi_memcpy4=__aeabi_memcpy -Wl,--defsym=__aeabi_memcpy8=__aeabi_memcpy"]
 extern {}
 
@@ -45,6 +46,7 @@ pub unsafe extern "C" fn __aeabi_memcpy(dest: *mut u8, src: *const u8, n: usize)
     memcpy(dest, src, n);
 }
 
+#[cfg(not(test))]
 #[link_args = "-Wl,--defsym=__aeabi_memmove4=__aeabi_memmove -Wl,--defsym=__aeabi_memmove8=__aeabi_memmove"]
 extern {}
 
@@ -53,6 +55,7 @@ pub unsafe extern "C" fn __aeabi_memmove(dest: *mut u8, src: *const u8, n: usize
     memmove(dest, src, n);
 }
 
+#[cfg(not(test))]
 #[link_args = "-Wl,--defsym=__aeabi_memset4=__aeabi_memset -Wl,--defsym=__aeabi_memset8=__aeabi_memset"]
 extern {}
 
@@ -62,6 +65,7 @@ pub unsafe extern "C" fn __aeabi_memset(dest: *mut u8, n: usize, c: i32) {
     memset(dest, c, n);
 }
 
+#[cfg(not(test))]
 #[link_args = "-Wl,--defsym=__aeabi_memclr4=__aeabi_memclr -Wl,--defsym=__aeabi_memclr8=__aeabi_memclr"]
 extern {}
 

--- a/src/arm.rs
+++ b/src/arm.rs
@@ -36,57 +36,36 @@ extern "C" {
     fn memset(dest: *mut u8, c: i32, n: usize) -> *mut u8;
 }
 
-// FIXME: The `*4` and `*8` variants should be defined as aliases.
+// Create aliases for the *4 and *8 variants
+#[link_args = "-Wl,--defsym=__aeabi_memcpy4=__aeabi_memcpy -Wl,--defsym=__aeabi_memcpy8=__aeabi_memcpy"]
+extern {}
 
 #[cfg_attr(not(test), no_mangle)]
 pub unsafe extern "C" fn __aeabi_memcpy(dest: *mut u8, src: *const u8, n: usize) {
     memcpy(dest, src, n);
 }
-#[cfg_attr(not(test), no_mangle)]
-pub unsafe extern "C" fn __aeabi_memcpy4(dest: *mut u8, src: *const u8, n: usize) {
-    memcpy(dest, src, n);
-}
-#[cfg_attr(not(test), no_mangle)]
-pub unsafe extern "C" fn __aeabi_memcpy8(dest: *mut u8, src: *const u8, n: usize) {
-    memcpy(dest, src, n);
-}
+
+#[link_args = "-Wl,--defsym=__aeabi_memmove4=__aeabi_memmove -Wl,--defsym=__aeabi_memmove8=__aeabi_memmove"]
+extern {}
 
 #[cfg_attr(not(test), no_mangle)]
 pub unsafe extern "C" fn __aeabi_memmove(dest: *mut u8, src: *const u8, n: usize) {
     memmove(dest, src, n);
 }
-#[cfg_attr(not(test), no_mangle)]
-pub unsafe extern "C" fn __aeabi_memmove4(dest: *mut u8, src: *const u8, n: usize) {
-    memmove(dest, src, n);
-}
-#[cfg_attr(not(test), no_mangle)]
-pub unsafe extern "C" fn __aeabi_memmove8(dest: *mut u8, src: *const u8, n: usize) {
-    memmove(dest, src, n);
-}
+
+#[link_args = "-Wl,--defsym=__aeabi_memset4=__aeabi_memset -Wl,--defsym=__aeabi_memset8=__aeabi_memset"]
+extern {}
 
 // Note the different argument order
 #[cfg_attr(not(test), no_mangle)]
 pub unsafe extern "C" fn __aeabi_memset(dest: *mut u8, n: usize, c: i32) {
     memset(dest, c, n);
 }
-#[cfg_attr(not(test), no_mangle)]
-pub unsafe extern "C" fn __aeabi_memset4(dest: *mut u8, n: usize, c: i32) {
-    memset(dest, c, n);
-}
-#[cfg_attr(not(test), no_mangle)]
-pub unsafe extern "C" fn __aeabi_memset8(dest: *mut u8, n: usize, c: i32) {
-    memset(dest, c, n);
-}
+
+#[link_args = "-Wl,--defsym=__aeabi_memclr4=__aeabi_memclr -Wl,--defsym=__aeabi_memclr8=__aeabi_memclr"]
+extern {}
 
 #[cfg_attr(not(test), no_mangle)]
 pub unsafe extern "C" fn __aeabi_memclr(dest: *mut u8, n: usize) {
-    memset(dest, 0, n);
-}
-#[cfg_attr(not(test), no_mangle)]
-pub unsafe extern "C" fn __aeabi_memclr4(dest: *mut u8, n: usize) {
-    memset(dest, 0, n);
-}
-#[cfg_attr(not(test), no_mangle)]
-pub unsafe extern "C" fn __aeabi_memclr8(dest: *mut u8, n: usize) {
     memset(dest, 0, n);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 #![feature(asm)]
 #![feature(core_intrinsics)]
 #![feature(linkage)]
+#![feature(link_args)]
 #![feature(naked_functions)]
 #![cfg_attr(not(test), no_std)]
 #![no_builtins]


### PR DESCRIPTION
This is a bit of a hack, but it seems to me like the best way we have to create function aliases right now. It's up to you whether this is better than just having more function stubs.

Note that I haven't actually tested this yet as I don't have access to my arm toolchain.