### PR TITLE
Add x86_64 builtins

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,8 +133,8 @@ See [rust-lang/rust#35437][0].
 - [x] udivsi3.c
 - [x] umoddi3.c
 - [x] umodsi3.c
-- [ ] x86_64/chkstk.S
-- [ ] x86_64/chkstk2.S
+- [x] x86_64/chkstk.S
+- [x] x86_64/chkstk2.S
 
 These builtins are needed to support 128-bit integers, which are in the process of being added to Rust.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,9 @@ extern crate rlibc;
 #[cfg(target_arch = "arm")]
 pub mod arm;
 
+#[cfg(target_arch = "x86_64")]
+pub mod x86_64;
+
 pub mod udiv;
 pub mod mul;
 pub mod shift;

--- a/src/x86_64.rs
+++ b/src/x86_64.rs
@@ -2,9 +2,13 @@ use core::intrinsics;
 
 // NOTE These functions are implemented using assembly because they using a custom
 // calling convention which can't be implemented using a normal Rust function
+
+// NOTE These functions are never mangled as they are not tested against compiler-rt
+// and mangling ___chkstk would break the `jmp ___chkstk` instruction in __alloca
+
 #[cfg(windows)]
 #[naked]
-#[cfg_attr(not(test), no_mangle)]
+#[no_mangle]
 pub unsafe fn ___chkstk_ms() {
     asm!("push   %rcx
           push   %rax
@@ -28,7 +32,7 @@ pub unsafe fn ___chkstk_ms() {
 
 #[cfg(windows)]
 #[naked]
-#[cfg_attr(not(test), no_mangle)]
+#[no_mangle]
 pub unsafe fn __alloca() {
     asm!("mov    %rcx,%rax  // x64 _alloca is a normal function with parameter in rcx
           jmp    ___chkstk  // Jump to ___chkstk since fallthrough may be unreliable");
@@ -37,7 +41,7 @@ pub unsafe fn __alloca() {
 
 #[cfg(windows)]
 #[naked]
-#[cfg_attr(not(test), no_mangle)]
+#[no_mangle]
 pub unsafe fn ___chkstk() {
     asm!("push   %rcx
           cmp    $$0x1000,%rax

--- a/src/x86_64.rs
+++ b/src/x86_64.rs
@@ -30,12 +30,9 @@ pub unsafe fn ___chkstk_ms() {
 #[naked]
 #[cfg_attr(not(test), no_mangle)]
 pub unsafe fn __alloca() {
-    asm!("mov    %rcx,%rax  // x64 _alloca is a normal function with parameter in rcx");
-    // The original behavior had __alloca fall through to ___chkstk here, but
-    // I don't believe that this behavior is guaranteed, and a program that uses
-    // only __alloca could have ___chkstk removed by --gc-sections. Call 
-    // ___chkstk here to guarantee that neither of those happen.
-    ___chkstk();
+    asm!("mov    %rcx,%rax  // x64 _alloca is a normal function with parameter in rcx
+          jmp    ___chkstk  // Jump to ___chkstk since fallthrough may be unreliable");
+    intrinsics::unreachable();
 }
 
 #[cfg(windows)]

--- a/src/x86_64.rs
+++ b/src/x86_64.rs
@@ -1,0 +1,67 @@
+use core::intrinsics;
+
+// NOTE These functions are implemented using assembly because they using a custom
+// calling convention which can't be implemented using a normal Rust function
+#[cfg(windows)]
+#[naked]
+#[cfg_attr(not(test), no_mangle)]
+pub unsafe fn ___chkstk_ms() {
+    asm!("push   %rcx
+          push   %rax
+          cmp    $$0x1000,%rax
+          lea    24(%rsp),%rcx
+          jb     1f
+          2:
+          sub    $$0x1000,%rcx
+          test   %rcx,(%rcx)
+          sub    $$0x1000,%rax
+          cmp    $$0x1000,%rax
+          ja     2b
+          1:
+          sub    %rax,%rcx
+          test   %rcx,(%rcx)
+          pop    %rax
+          pop    %rcx
+          ret");
+    intrinsics::unreachable();
+}
+
+#[cfg(windows)]
+#[naked]
+#[cfg_attr(not(test), no_mangle)]
+pub unsafe fn __alloca() {
+    asm!("mov    %rcx,%rax  // x64 _alloca is a normal function with parameter in rcx");
+    // The original behavior had __alloca fall through to ___chkstk here, but
+    // I don't believe that this behavior is guaranteed, and a program that uses
+    // only __alloca could have ___chkstk removed by --gc-sections. Call 
+    // ___chkstk here to guarantee that neither of those happen.
+    ___chkstk();
+}
+
+#[cfg(windows)]
+#[naked]
+#[cfg_attr(not(test), no_mangle)]
+pub unsafe fn ___chkstk() {
+    asm!("push   %rcx
+          cmp    $$0x1000,%rax
+          lea    16(%rsp),%rcx  // rsp before calling this routine -> rcx
+          jb     1f
+          2:
+          sub    $$0x1000,%rcx
+          test   %rcx,(%rcx)
+          sub    $$0x1000,%rax
+          cmp    $$0x1000,%rax
+          ja     2b
+          1:
+          sub    %rax,%rcx
+          test   %rcx,(%rcx)
+
+          lea    8(%rsp),%rax   // load pointer to the return address into rax
+          mov    %rcx,%rsp      // install the new top of stack pointer into rsp
+          mov    -8(%rax),%rcx  // restore rcx
+          push   (%rax)         // push return address onto the stack
+          sub    %rsp,%rax      // restore the original value in rax
+          ret");
+    intrinsics::unreachable();
+}
+


### PR DESCRIPTION
This is a fairly straightforward port of the original assembly files. I'm hoping to help port a whole bunch of these builtins over the next few days, so let me know if you have any style or other concerns. I don't believe that these functions have any tests in compiler-rt and they would be quite difficult functions to test. Nonetheless, I'm going to attempt to find a windows binary that exercises these and swap them in to see if anything breaks.

Two notes:
- `__alloca` falls through to `___chkstk` in the original assembly. I think having a function call there is the best way to implement this reliably, other than duplicating the assembly.
- The original assembly files don't appear to be conditionally compiled, but are noted as only being used on Windows, so I am conditionally compiling them now.