### PR TITLE
appveyor: inspect binaries

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,6 +17,8 @@ test_script:
   - cargo build --release
   - cargo test
   - cargo test --release
+  - dumpbin /disasm target/debug/librustc_builtins.rlib
+  - dumpbin /disasm target/release/librustc_builtins.rlib
 
 branches:
   only:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,8 +18,8 @@ test_script:
   - cargo test
   - cargo test --release
   - CALL "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat"
-  - dumpbin /disasm target/debug/librustc_builtins.rlib
-  - dumpbin /disasm target/release/librustc_builtins.rlib
+  - dumpbin /disasm target/debug/librustc_builtins.rlib || exit 0
+  - dumpbin /disasm target/release/librustc_builtins.rlib || exit 0
 
 branches:
   only:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,6 +17,7 @@ test_script:
   - cargo build --release
   - cargo test
   - cargo test --release
+  - CALL "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat"
   - dumpbin /disasm target/debug/librustc_builtins.rlib
   - dumpbin /disasm target/release/librustc_builtins.rlib
 


### PR DESCRIPTION
Fixed #27 to source `vcvarsall.bat` before calling dumpbin. Closes #12