### PR TITLE
add an opt-in cargo feature to build intrinsics from compiler-rt source

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: rust
 services: docker
 sudo: required
 rust: nightly
-cache: cargo
 
 matrix:
   include:
@@ -25,18 +24,11 @@ matrix:
     - env: TARGET=mipsel-unknown-linux-gnu
     - env: TARGET=powerpc-unknown-linux-gnu
     - env: TARGET=powerpc64-unknown-linux-gnu
-    # QEMU crashes even when executing the simplest cross compiled C program:
-    # `int main() { return 0; }`
-    - env: TARGET=powerpc64le-unknown-linux-gnu NO_RUN=1
+    - env: TARGET=powerpc64le-unknown-linux-gnu
     - env: TARGET=thumbv6m-none-eabi
-      install: cargo install xargo --debug -f
-      script: $HOME/.cargo/bin/xargo build --target $TARGET
     - env: TARGET=thumbv7em-none-eabi
-      install: cargo install xargo --debug -f
-      script: $HOME/.cargo/bin/xargo build --target $TARGET
     - env: TARGET=thumbv7em-none-eabihf
-      install: cargo install xargo --debug -f
-      script: $HOME/.cargo/bin/xargo build --target $TARGET
+    - env: TARGET=thumbv7m-none-eabi
     - env: TARGET=x86_64-apple-darwin
       os: osx
 env: TARGET=x86_64-unknown-linux-gnu
@@ -45,8 +37,10 @@ before_install:
   - test "$TRAVIS_OS_NAME" = "osx" || docker run --rm --privileged multiarch/qemu-user-static:register
 
 install:
-  - curl https://static.rust-lang.org/rustup.sh |
-    sh -s -- --add-target=$TARGET --disable-sudo -y --prefix=`rustc --print sysroot`
+  - if case $TARGET in thumb*) false;; *) true;; esac; then
+      curl https://static.rust-lang.org/rustup.sh |
+      sh -s -- --add-target=$TARGET --disable-sudo -y --prefix=`rustc --print sysroot`;
+    fi
 
 script:
   - cargo generate-lockfile

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,10 @@ build = "build.rs"
 name = "rustc_builtins"
 version = "0.1.0"
 
+[build-dependencies]
+gcc = "0.3.35"
+rustc-cfg = "0.1.2"
+
 [dependencies]
 
 [dependencies.rlibc]
@@ -17,6 +21,8 @@ gcc_s = { path = "gcc_s" }
 compiler-rt = { path = "compiler-rt" }
 
 [features]
+# Build the missing intrinsics from compiler-rt C source code
+c = []
 weak = ["rlibc/weak"]
 
 [workspace]

--- a/build.rs
+++ b/build.rs
@@ -1,8 +1,430 @@
+extern crate gcc;
+extern crate rustc_cfg;
+
+use std::collections::BTreeMap;
 use std::env;
+use std::path::Path;
+
+use rustc_cfg::Cfg;
+
+struct Sources {
+    // SYMBOL -> PATH TO SOURCE
+    map: BTreeMap<&'static str, &'static str>,
+}
+
+impl Sources {
+    fn new() -> Sources {
+        Sources { map: BTreeMap::new() }
+    }
+
+    fn extend(&mut self, sources: &[&'static str]) {
+        // NOTE Some intrinsics have both a generic implementation (e.g.
+        // `floatdidf.c`) and an arch optimized implementation
+        // (`x86_64/floatdidf.c`). In those cases, we keep the arch optimized
+        // implementation and discard the generic implementation. If we don't
+        // and keep both implementations, the linker will yell at us about
+        // duplicate symbols!
+        for &src in sources {
+            let symbol = Path::new(src).file_stem().unwrap().to_str().unwrap();
+            if src.contains("/") {
+                // Arch-optimized implementation (preferred)
+                self.map.insert(symbol, src);
+            } else {
+                // Generic implementation
+                if !self.map.contains_key(symbol) {
+                    self.map.insert(symbol, src);
+                }
+            }
+        }
+    }
+
+    fn remove(&mut self, symbols: &[&str]) {
+        for symbol in symbols {
+            self.map.remove(*symbol).unwrap();
+        }
+    }
+}
 
 fn main() {
-    if env::var("TARGET").unwrap().ends_with("gnueabihf") {
+    println!("cargo:rerun-if-changed=build.rs");
+
+    let target = env::var("TARGET").unwrap();
+    let Cfg { ref target_arch, ref target_os, ref target_env, ref target_vendor, .. } =
+        Cfg::new(&target).unwrap();
+    // NOTE we are going to assume that llvm-target, what determines our codegen option, matches the
+    // target triple. This is usually correct for our built-in targets but can break in presence of
+    // custom targets, which can have arbitrary names.
+    let llvm_target = target.split('-').collect::<Vec<_>>();
+    let target_vendor = target_vendor.as_ref().unwrap();
+
+    // Build missing intrinsics from compiler-rt C source code
+    if env::var_os("CARGO_FEATURE_C").is_some() {
+        let cfg = &mut gcc::Config::new();
+
+        if target_env == "msvc" {
+            // Don't pull in extra libraries on MSVC
+            cfg.flag("/Zl");
+
+            // Emulate C99 and C++11's __func__ for MSVC prior to 2013 CTP
+            cfg.define("__func__", Some("__FUNCTION__"));
+        } else {
+            // Turn off various features of gcc and such, mostly copying
+            // compiler-rt's build system already
+            cfg.flag("-fno-builtin");
+            cfg.flag("-fvisibility=hidden");
+            cfg.flag("-fomit-frame-pointer");
+            cfg.flag("-ffreestanding");
+        }
+
+        // NOTE Most of the ARM intrinsics are written in assembly. Tell gcc which arch we are going to
+        // target to make sure that the assembly implementations really work for the target. If the
+        // implementation is not valid for the arch, then gcc will error when compiling it.
+        if llvm_target[0].starts_with("thumb") {
+            cfg.flag("-mthumb");
+
+            if llvm_target.last() == Some(&"eabihf") {
+                cfg.flag("-mfloat-abi=hard");
+            }
+        }
+
+        if llvm_target[0] == "thumbv6m" {
+            cfg.flag("-march=armv6-m");
+        }
+
+        if llvm_target[0] == "thumbv7m" {
+            cfg.flag("-march=armv7-m");
+        }
+
+        if llvm_target[0] == "thumbv7em" {
+            cfg.flag("-march=armv7e-m");
+        }
+
+        let mut sources = Sources::new();
+        sources.extend(&["absvdi2.c",
+                         "absvsi2.c",
+                         "addvdi3.c",
+                         "addvsi3.c",
+                         "apple_versioning.c",
+                         "clear_cache.c",
+                         "clzdi2.c",
+                         "clzsi2.c",
+                         "cmpdi2.c",
+                         "comparedf2.c",
+                         "comparesf2.c",
+                         "ctzdi2.c",
+                         "ctzsi2.c",
+                         "divdc3.c",
+                         "divdf3.c",
+                         "divsc3.c",
+                         "divsf3.c",
+                         "divxc3.c",
+                         "extendsfdf2.c",
+                         "extendhfsf2.c",
+                         "ffsdi2.c",
+                         "fixdfdi.c",
+                         "fixdfsi.c",
+                         "fixsfdi.c",
+                         "fixsfsi.c",
+                         "fixunsdfdi.c",
+                         "fixunsdfsi.c",
+                         "fixunssfdi.c",
+                         "fixunssfsi.c",
+                         "fixunsxfdi.c",
+                         "fixunsxfsi.c",
+                         "fixxfdi.c",
+                         "floatdidf.c",
+                         "floatdisf.c",
+                         "floatdixf.c",
+                         "floatsidf.c",
+                         "floatsisf.c",
+                         "floatundidf.c",
+                         "floatundisf.c",
+                         "floatundixf.c",
+                         "floatunsidf.c",
+                         "floatunsisf.c",
+                         "int_util.c",
+                         "muldc3.c",
+                         "muldf3.c",
+                         "muloti4.c",
+                         "mulsc3.c",
+                         "mulsf3.c",
+                         "mulvdi3.c",
+                         "mulvsi3.c",
+                         "mulxc3.c",
+                         "negdf2.c",
+                         "negdi2.c",
+                         "negsf2.c",
+                         "negvdi2.c",
+                         "negvsi2.c",
+                         "paritydi2.c",
+                         "paritysi2.c",
+                         "popcountdi2.c",
+                         "popcountsi2.c",
+                         "powidf2.c",
+                         "powisf2.c",
+                         "powixf2.c",
+                         "subdf3.c",
+                         "subsf3.c",
+                         "subvdi3.c",
+                         "subvsi3.c",
+                         "truncdfhf2.c",
+                         "truncdfsf2.c",
+                         "truncsfhf2.c",
+                         "ucmpdi2.c"]);
+
+        if target_os != "ios" {
+            sources.extend(&["absvti2.c",
+                             "addtf3.c",
+                             "addvti3.c",
+                             "ashlti3.c",
+                             "ashrti3.c",
+                             "clzti2.c",
+                             "cmpti2.c",
+                             "ctzti2.c",
+                             "divtf3.c",
+                             "divti3.c",
+                             "ffsti2.c",
+                             "fixdfti.c",
+                             "fixsfti.c",
+                             "fixunsdfti.c",
+                             "fixunssfti.c",
+                             "fixunsxfti.c",
+                             "fixxfti.c",
+                             "floattidf.c",
+                             "floattisf.c",
+                             "floattixf.c",
+                             "floatuntidf.c",
+                             "floatuntisf.c",
+                             "floatuntixf.c",
+                             "lshrti3.c",
+                             "modti3.c",
+                             "multf3.c",
+                             "multi3.c",
+                             "mulvti3.c",
+                             "negti2.c",
+                             "negvti2.c",
+                             "parityti2.c",
+                             "popcountti2.c",
+                             "powitf2.c",
+                             "subtf3.c",
+                             "subvti3.c",
+                             "trampoline_setup.c",
+                             "ucmpti2.c",
+                             "udivmodti4.c",
+                             "udivti3.c",
+                             "umodti3.c"]);
+        }
+
+        if target_vendor == "apple" {
+            sources.extend(&["atomic_flag_clear.c",
+                             "atomic_flag_clear_explicit.c",
+                             "atomic_flag_test_and_set.c",
+                             "atomic_flag_test_and_set_explicit.c",
+                             "atomic_signal_fence.c",
+                             "atomic_thread_fence.c"]);
+        }
+
+        if target_os != "windows" && target_os != "none" {
+            sources.extend(&["emutls.c"]);
+        }
+
+        if target_env == "msvc" {
+            if target_arch == "x86_64" {
+                sources.extend(&["x86_64/floatdidf.c", "x86_64/floatdisf.c", "x86_64/floatdixf.c"]);
+            }
+        } else {
+            if target_os != "freebsd" {
+                sources.extend(&["gcc_personality_v0.c"]);
+            }
+
+            if target_arch == "x86_64" {
+                sources.extend(&["x86_64/chkstk.S",
+                                 "x86_64/chkstk2.S",
+                                 "x86_64/floatdidf.c",
+                                 "x86_64/floatdisf.c",
+                                 "x86_64/floatdixf.c",
+                                 "x86_64/floatundidf.S",
+                                 "x86_64/floatundisf.S",
+                                 "x86_64/floatundixf.S"]);
+            }
+
+            if target_arch == "x86" {
+                sources.extend(&["i386/ashldi3.S",
+                                 "i386/ashrdi3.S",
+                                 "i386/chkstk.S",
+                                 "i386/chkstk2.S",
+                                 "i386/divdi3.S",
+                                 "i386/floatdidf.S",
+                                 "i386/floatdisf.S",
+                                 "i386/floatdixf.S",
+                                 "i386/floatundidf.S",
+                                 "i386/floatundisf.S",
+                                 "i386/floatundixf.S",
+                                 "i386/lshrdi3.S",
+                                 "i386/moddi3.S",
+                                 "i386/muldi3.S",
+                                 "i386/udivdi3.S",
+                                 "i386/umoddi3.S"]);
+            }
+        }
+
+        if target_arch == "arm" && target_os != "ios" {
+            sources.extend(&["arm/aeabi_cdcmp.S",
+                             "arm/aeabi_cdcmpeq_check_nan.c",
+                             "arm/aeabi_cfcmp.S",
+                             "arm/aeabi_cfcmpeq_check_nan.c",
+                             "arm/aeabi_dcmp.S",
+                             "arm/aeabi_div0.c",
+                             "arm/aeabi_drsub.c",
+                             "arm/aeabi_fcmp.S",
+                             "arm/aeabi_frsub.c",
+                             "arm/bswapdi2.S",
+                             "arm/bswapsi2.S",
+                             "arm/clzdi2.S",
+                             "arm/clzsi2.S",
+                             "arm/comparesf2.S",
+                             "arm/divmodsi4.S",
+                             "arm/divsi3.S",
+                             "arm/modsi3.S",
+                             "arm/switch16.S",
+                             "arm/switch32.S",
+                             "arm/switch8.S",
+                             "arm/switchu8.S",
+                             "arm/sync_synchronize.S",
+                             "arm/udivmodsi4.S",
+                             "arm/udivsi3.S",
+                             "arm/umodsi3.S"]);
+        }
+
+        if llvm_target[0] == "armv7" {
+            sources.extend(&["arm/sync_fetch_and_add_4.S",
+                             "arm/sync_fetch_and_add_8.S",
+                             "arm/sync_fetch_and_and_4.S",
+                             "arm/sync_fetch_and_and_8.S",
+                             "arm/sync_fetch_and_max_4.S",
+                             "arm/sync_fetch_and_max_8.S",
+                             "arm/sync_fetch_and_min_4.S",
+                             "arm/sync_fetch_and_min_8.S",
+                             "arm/sync_fetch_and_nand_4.S",
+                             "arm/sync_fetch_and_nand_8.S",
+                             "arm/sync_fetch_and_or_4.S",
+                             "arm/sync_fetch_and_or_8.S",
+                             "arm/sync_fetch_and_sub_4.S",
+                             "arm/sync_fetch_and_sub_8.S",
+                             "arm/sync_fetch_and_umax_4.S",
+                             "arm/sync_fetch_and_umax_8.S",
+                             "arm/sync_fetch_and_umin_4.S",
+                             "arm/sync_fetch_and_umin_8.S",
+                             "arm/sync_fetch_and_xor_4.S",
+                             "arm/sync_fetch_and_xor_8.S"]);
+        }
+
+        if llvm_target.last().unwrap().ends_with("eabihf") {
+            if !llvm_target[0].starts_with("thumbv7em") {
+                sources.extend(&["arm/adddf3vfp.S",
+                                 "arm/addsf3vfp.S",
+                                 "arm/divdf3vfp.S",
+                                 "arm/divsf3vfp.S",
+                                 "arm/eqdf2vfp.S",
+                                 "arm/eqsf2vfp.S",
+                                 "arm/extendsfdf2vfp.S",
+                                 "arm/fixdfsivfp.S",
+                                 "arm/fixsfsivfp.S",
+                                 "arm/fixunsdfsivfp.S",
+                                 "arm/fixunssfsivfp.S",
+                                 "arm/floatsidfvfp.S",
+                                 "arm/floatsisfvfp.S",
+                                 "arm/floatunssidfvfp.S",
+                                 "arm/floatunssisfvfp.S",
+                                 "arm/gedf2vfp.S",
+                                 "arm/gesf2vfp.S",
+                                 "arm/gtdf2vfp.S",
+                                 "arm/gtsf2vfp.S",
+                                 "arm/ledf2vfp.S",
+                                 "arm/lesf2vfp.S",
+                                 "arm/ltdf2vfp.S",
+                                 "arm/ltsf2vfp.S",
+                                 "arm/muldf3vfp.S",
+                                 "arm/mulsf3vfp.S",
+                                 "arm/nedf2vfp.S",
+                                 "arm/nesf2vfp.S",
+                                 "arm/restore_vfp_d8_d15_regs.S",
+                                 "arm/save_vfp_d8_d15_regs.S",
+                                 "arm/subdf3vfp.S",
+                                 "arm/subsf3vfp.S"]);
+            }
+
+            sources.extend(&["arm/negdf2vfp.S", "arm/negsf2vfp.S"]);
+
+        }
+
+        if target_arch == "aarch64" {
+            sources.extend(&["comparetf2.c",
+                             "extenddftf2.c",
+                             "extendsftf2.c",
+                             "fixtfdi.c",
+                             "fixtfsi.c",
+                             "fixtfti.c",
+                             "fixunstfdi.c",
+                             "fixunstfsi.c",
+                             "fixunstfti.c",
+                             "floatditf.c",
+                             "floatsitf.c",
+                             "floatunditf.c",
+                             "floatunsitf.c",
+                             "multc3.c",
+                             "trunctfdf2.c",
+                             "trunctfsf2.c"]);
+        }
+
+        // Remove the assembly implementations that won't compile for the target
+        if llvm_target[0] == "thumbv6m" {
+            sources.remove(&["aeabi_cdcmp",
+                             "aeabi_cfcmp",
+                             "aeabi_dcmp",
+                             "aeabi_fcmp",
+                             "clzdi2",
+                             "clzsi2",
+                             "comparesf2",
+                             "divmodsi4",
+                             "divsi3",
+                             "modsi3",
+                             "switch16",
+                             "switch32",
+                             "switch8",
+                             "switchu8",
+                             "udivmodsi4",
+                             "udivsi3",
+                             "umodsi3"]);
+
+            // But use some generic implementations where possible
+            sources.extend(&["clzdi2.c", "clzsi2.c"])
+        }
+
+        if llvm_target[0] == "thumbv7m" || llvm_target[0] == "thumbv7em" {
+            sources.remove(&["aeabi_cdcmp", "aeabi_cfcmp"]);
+        }
+
+        for src in sources.map.values() {
+            cfg.file(Path::new("compiler-rt/lib/builtins").join(src));
+        }
+
+        cfg.compile("libcompiler-rt.a");
+    }
+
+    // To filter away some flaky test (see src/float/add.rs for details)
+    if llvm_target.last() == Some(&"gnueabihf") {
         println!("cargo:rustc-cfg=gnueabihf")
     }
-    println!("cargo:rerun-if-changed=build.rs");
+
+    // To compile intrinsics.rs for thumb targets, where there is no libc
+    if llvm_target[0].starts_with("thumb") {
+        println!("cargo:rustc-cfg=thumb")
+    }
+
+    // compiler-rt `cfg`s away some intrinsics for thumbv6m because that target doesn't have full
+    // THUMBv2 support. We have to cfg our code accordingly.
+    if llvm_target[0] == "thumbv6m" {
+        println!("cargo:rustc-cfg=thumbv6m")
+    }
 }

--- a/build.rs
+++ b/build.rs
@@ -406,7 +406,9 @@ fn main() {
         }
 
         for src in sources.map.values() {
-            cfg.file(Path::new("compiler-rt/compiler-rt-cdylib/compiler-rt/lib/builtins").join(src));
+            let src = Path::new("compiler-rt/compiler-rt-cdylib/compiler-rt/lib/builtins").join(src);
+            cfg.file(&src);
+            println!("cargo:rerun-if-changed={}", src.display());
         }
 
         cfg.compile("libcompiler-rt.a");

--- a/build.rs
+++ b/build.rs
@@ -406,7 +406,7 @@ fn main() {
         }
 
         for src in sources.map.values() {
-            cfg.file(Path::new("compiler-rt/lib/builtins").join(src));
+            cfg.file(Path::new("compiler-rt/compiler-rt-cdylib/compiler-rt/lib/builtins").join(src));
         }
 
         cfg.compile("libcompiler-rt.a");

--- a/ci/docker/thumbv6m-none-eabi/Dockerfile
+++ b/ci/docker/thumbv6m-none-eabi/Dockerfile
@@ -1,0 +1,8 @@
+FROM ubuntu:16.04
+RUN apt-get update
+RUN apt-get install -y --no-install-recommends \
+    ca-certificates curl gcc gcc-arm-none-eabi libc6-dev libcurl4-openssl-dev libssh2-1 libnewlib-dev
+ENV AR_thumbv6m_none_eabi=arm-none-eabi-ar \
+    CARGO_TARGET_THUMBV6M_NONE_EABI_LINKER=arm-none-eabi-gcc \
+    CC_thumbv6m_none_eabi=arm-none-eabi-gcc \
+    PATH=$PATH:/rust/bin

--- a/ci/docker/thumbv7em-none-eabi/Dockerfile
+++ b/ci/docker/thumbv7em-none-eabi/Dockerfile
@@ -1,0 +1,8 @@
+FROM ubuntu:16.04
+RUN apt-get update
+RUN apt-get install -y --no-install-recommends \
+    ca-certificates curl gcc gcc-arm-none-eabi libc6-dev libcurl4-openssl-dev libssh2-1 libnewlib-dev
+ENV AR_thumbv7em_none_eabi=arm-none-eabi-ar \
+    CARGO_TARGET_THUMBV7EM_NONE_EABI_LINKER=arm-none-eabi-gcc \
+    CC_thumbv7em_none_eabi=arm-none-eabi-gcc \
+    PATH=$PATH:/rust/bin

--- a/ci/docker/thumbv7em-none-eabihf/Dockerfile
+++ b/ci/docker/thumbv7em-none-eabihf/Dockerfile
@@ -1,0 +1,8 @@
+FROM ubuntu:16.04
+RUN apt-get update
+RUN apt-get install -y --no-install-recommends \
+    ca-certificates curl gcc gcc-arm-none-eabi libc6-dev libcurl4-openssl-dev libssh2-1 libnewlib-dev
+ENV AR_thumbv7em_none_eabihf=arm-none-eabi-ar \
+    CARGO_TARGET_THUMBV7EM_NONE_EABIHF_LINKER=arm-none-eabi-gcc \
+    CC_thumbv7em_none_eabihf=arm-none-eabi-gcc \
+    PATH=$PATH:/rust/bin

--- a/ci/docker/thumbv7m-none-eabi/Dockerfile
+++ b/ci/docker/thumbv7m-none-eabi/Dockerfile
@@ -1,0 +1,8 @@
+FROM ubuntu:16.04
+RUN apt-get update
+RUN apt-get install -y --no-install-recommends \
+    ca-certificates curl gcc gcc-arm-none-eabi libc6-dev libcurl4-openssl-dev libssh2-1 libnewlib-dev
+ENV AR_thumbv7m_none_eabi=arm-none-eabi-ar \
+    CARGO_TARGET_THUMBV7M_NONE_EABI_LINKER=arm-none-eabi-gcc \
+    CC_thumbv7m_none_eabi=arm-none-eabi-gcc \
+    PATH=$PATH:/rust/bin

--- a/ci/run-docker.sh
+++ b/ci/run-docker.sh
@@ -5,19 +5,15 @@ set -ex
 
 run() {
     echo $1
-    CMD="cargo test --target $1"
-    if [ "$NO_RUN" = "1" ]; then
-        CMD="$CMD --no-run"
-    fi
-    docker build -t libc ci/docker/$1
+    docker build -t $1 ci/docker/$1
     docker run \
       -v `rustc --print sysroot`:/rust:ro \
       -v `pwd`:/checkout:ro \
       -e CARGO_TARGET_DIR=/tmp/target \
       -w /checkout \
       --privileged \
-      -it libc \
-      bash -c "$CMD && $CMD --release"
+      -it $1 \
+      sh ci/run.sh $1
 }
 
 if [ -z "$1" ]; then

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -55,8 +55,9 @@ case $TRAVIS_OS_NAME in
         ;;
 esac
 
+# NOTE On i586, It's normal that the get_pc_thunk symbol appears several times so ignore it
 $PREFIX$NM -g --defined-only /tmp/target/${1}/debug/librustc_builtins.rlib | \
-    sort | uniq -d | grep 'T __'
+    sort | uniq -d | grep -v __x86.get_pc_thunk | grep 'T __'
 
 if test $? = 0; then
     exit 1

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -1,0 +1,63 @@
+# Test our implementation
+case $1 in
+    thumb*)
+        curl -sf "https://raw.githubusercontent.com/japaric/rust-everywhere/master/install.sh" | \
+            bash -s -- --at /usr/bin --from japaric/xargo --tag v0.1.10
+        xargo build --target $1
+        xargo build --target $1 --release
+        ;;
+    # QEMU crashes even when executing the simplest cross compiled C program:
+    # `int main() { return 0; }`
+    powerpc64le-unknown-linux-gnu)
+        cargo test --target $1 --no-run
+        cargo test --target $1 --no-run --release
+        ;;
+    *)
+        cargo test --target $1
+        cargo test --target $1 --release
+        ;;
+esac
+
+# Verify that we haven't drop any intrinsic/symbol
+case $1 in
+    thumb*)
+        xargo build --features c --target $1 --bin intrinsics
+        ;;
+    *)
+        cargo build --features c --target $1 --bin intrinsics
+        ;;
+esac
+
+# Look out for duplicated symbols when we include the compiler-rt (C) implementation
+PREFIX=$(echo $1 | sed -e 's/unknown-//')
+case $1 in
+    armv7-*)
+        PREFIX=arm-linux-gnueabihf-
+        ;;
+    thumb*)
+        PREFIX=arm-none-eabi-
+        ;;
+    *-unknown-linux-gnu | *-apple-darwin)
+        PREFIX=
+        ;;
+esac
+
+case $TRAVIS_OS_NAME in
+    osx)
+        NM=gnm
+
+        # NOTE OSx's nm doesn't accept the `--defined-only` or provide an equivalent.
+        # Use GNU nm instead
+        brew install binutils
+        ;;
+    *)
+        NM=nm
+        ;;
+esac
+
+$PREFIX$NM -g --defined-only /tmp/target/${1}/debug/librustc_builtins.rlib | \
+    sort | uniq -d | grep 'T __'
+
+if test $? = 0; then
+    exit 1
+fi

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -37,7 +37,7 @@ case $1 in
     thumb*)
         PREFIX=arm-none-eabi-
         ;;
-    *-unknown-linux-gnu | *-apple-darwin)
+    *86*-*)
         PREFIX=
         ;;
 esac

--- a/src/arm.rs
+++ b/src/arm.rs
@@ -68,6 +68,7 @@ pub extern "C" fn __aeabi_fadd(a: f32, b: f32) -> f32 {
     ::float::add::__addsf3(a, b)
 }
 
+#[cfg(not(all(feature = "c", target_arch = "arm", not(target_os = "ios"), not(thumbv6m))))]
 #[cfg_attr(not(test), no_mangle)]
 pub extern "C" fn __aeabi_idiv(a: i32, b: i32) -> i32 {
     ::int::sdiv::__divsi3(a, b)
@@ -93,6 +94,7 @@ pub extern "C" fn __aeabi_lmul(a: u64, b: u64) -> u64 {
     ::int::mul::__muldi3(a, b)
 }
 
+#[cfg(not(all(feature = "c", target_arch = "arm", not(target_os = "ios"), not(thumbv6m))))]
 #[cfg_attr(not(test), no_mangle)]
 pub extern "C" fn __aeabi_uidiv(a: u32, b: u32) -> u32 {
     ::int::udiv::__udivsi3(a, b)

--- a/src/bin/intrinsics.rs
+++ b/src/bin/intrinsics.rs
@@ -1,0 +1,399 @@
+// By compiling this file we check that all the intrinsics we care about continue to be provided by
+// the `rustc_builtins` crate regardless of the changes we make to it. If we, by mistake, stop
+// compiling a C implementation and forget to implement that intrinsic in Rust, this file will fail
+// to link due to the missing intrinsic (symbol).
+
+#![allow(unused_features)]
+#![deny(dead_code)]
+#![feature(core_float)]
+#![feature(lang_items)]
+#![feature(libc)]
+#![feature(start)]
+#![no_std]
+#![cfg_attr(thumb, no_main)]
+
+#[cfg(not(thumb))]
+extern crate libc;
+extern crate rustc_builtins;
+
+// NOTE cfg(not(thumbv6m)) means that the operation is not supported on ARMv6-M at all. Not even
+// compiler-rt provides a C/assembly implementation.
+
+// Every function in this module maps will be lowered to an intrinsic by LLVM, if the platform
+// doesn't have native support for the operation used in the function. ARM has a naming convention
+// convention for its intrinsics that's different from other architectures; that's why some function
+// have an additional comment: the function name is the ARM name for the intrinsic and the comment
+// in the non-ARM name for the intrinsic.
+#[cfg(feature = "c")]
+mod intrinsics {
+    use core::num::Float;
+
+    // trunccdfsf2
+    pub fn aeabi_d2f(x: f64) -> f32 {
+        x as f32
+    }
+
+    // fixdfsi
+    pub fn aeabi_d2i(x: f64) -> i32 {
+        x as i32
+    }
+
+    // fixdfdi
+    #[cfg(not(thumbv6m))]
+    pub fn aeabi_d2l(x: f64) -> i64 {
+        x as i64
+    }
+
+    #[cfg(thumbv6m)]
+    pub fn aeabi_d2l(_: f64) -> i64 {
+        0
+    }
+
+    // fixunsdfsi
+    pub fn aeabi_d2uiz(x: f64) -> u32 {
+        x as u32
+    }
+
+    // fixunsdfdi
+    #[cfg(not(thumbv6m))]
+    pub fn aeabi_d2ulz(x: f64) -> u64 {
+        x as u64
+    }
+
+    #[cfg(thumbv6m)]
+    pub fn aeabi_d2ulz(_: f64) -> u64 {
+        0
+    }
+
+    // adddf3
+    pub fn aeabi_dadd(a: f64, b: f64) -> f64 {
+        a + b
+    }
+
+    // eqdf2
+    #[cfg(not(thumbv6m))]
+    pub fn aeabi_dcmpeq(a: f64, b: f64) -> bool {
+        a == b
+    }
+
+    #[cfg(thumbv6m)]
+    pub fn aeabi_dcmpeq(_: f64, _: f64) -> bool {
+        true
+    }
+
+    // gtdf2
+    #[cfg(not(thumbv6m))]
+    pub fn aeabi_dcmpgt(a: f64, b: f64) -> bool {
+        a > b
+    }
+
+    #[cfg(thumbv6m)]
+    pub fn aeabi_dcmpgt(_: f64, _: f64) -> bool {
+        true
+    }
+
+    // ltdf2
+    #[cfg(not(thumbv6m))]
+    pub fn aeabi_dcmplt(a: f64, b: f64) -> bool {
+        a < b
+    }
+
+    #[cfg(thumbv6m)]
+    pub fn aeabi_dcmplt(_: f64, _: f64) -> bool {
+        true
+    }
+
+    // divdf3
+    pub fn aeabi_ddiv(a: f64, b: f64) -> f64 {
+        a / b
+    }
+
+    // muldf3
+    pub fn aeabi_dmul(a: f64, b: f64) -> f64 {
+        a * b
+    }
+
+    // subdf3
+    pub fn aeabi_dsub(a: f64, b: f64) -> f64 {
+        a - b
+    }
+
+    // extendsfdf2
+    pub fn aeabi_f2d(x: f32) -> f64 {
+        x as f64
+    }
+
+    // fixsfsi
+    pub fn aeabi_f2iz(x: f32) -> i32 {
+        x as i32
+    }
+
+    // fixsfdi
+    #[cfg(not(thumbv6m))]
+    pub fn aeabi_f2lz(x: f32) -> i64 {
+        x as i64
+    }
+
+    #[cfg(thumbv6m)]
+    pub fn aeabi_f2lz(_: f32) -> i64 {
+        0
+    }
+
+    // fixunssfsi
+    pub fn aeabi_f2uiz(x: f32) -> u32 {
+        x as u32
+    }
+
+    // fixunssfdi
+    #[cfg(not(thumbv6m))]
+    pub fn aeabi_f2ulz(x: f32) -> u64 {
+        x as u64
+    }
+
+    #[cfg(thumbv6m)]
+    pub fn aeabi_f2ulz(_: f32) -> u64 {
+        0
+    }
+
+    // addsf3
+    pub fn aeabi_fadd(a: f32, b: f32) -> f32 {
+        a + b
+    }
+
+    // eqsf2
+    #[cfg(not(thumbv6m))]
+    pub fn aeabi_fcmpeq(a: f32, b: f32) -> bool {
+        a == b
+    }
+
+    #[cfg(thumbv6m)]
+    pub fn aeabi_fcmpeq(_: f32, _: f32) -> bool {
+        true
+    }
+
+    // gtsf2
+    #[cfg(not(thumbv6m))]
+    pub fn aeabi_fcmpgt(a: f32, b: f32) -> bool {
+        a > b
+    }
+
+    #[cfg(thumbv6m)]
+    pub fn aeabi_fcmpgt(_: f32, _: f32) -> bool {
+        true
+    }
+
+    // ltsf2
+    #[cfg(not(thumbv6m))]
+    pub fn aeabi_fcmplt(a: f32, b: f32) -> bool {
+        a < b
+    }
+
+    #[cfg(thumbv6m)]
+    pub fn aeabi_fcmplt(_: f32, _: f32) -> bool {
+        true
+    }
+
+    // divsf3
+    pub fn aeabi_fdiv(a: f32, b: f32) -> f32 {
+        a / b
+    }
+
+    // mulsf3
+    pub fn aeabi_fmul(a: f32, b: f32) -> f32 {
+        a * b
+    }
+
+    // subsf3
+    pub fn aeabi_fsub(a: f32, b: f32) -> f32 {
+        a - b
+    }
+
+    // floatsidf
+    pub fn aeabi_i2d(x: i32) -> f64 {
+        x as f64
+    }
+
+    // floatsisf
+    pub fn aeabi_i2f(x: i32) -> f32 {
+        x as f32
+    }
+
+    pub fn aeabi_idiv(a: i32, b: i32) -> i32 {
+        a.wrapping_div(b)
+    }
+
+    pub fn aeabi_idivmod(a: i32, b: i32) -> i32 {
+        a % b
+    }
+
+    // floatdidf
+    pub fn aeabi_l2d(x: i64) -> f64 {
+        x as f64
+    }
+
+    // floatdisf
+    pub fn aeabi_l2f(x: i64) -> f32 {
+        x as f32
+    }
+
+    // divdi3
+    pub fn aeabi_ldivmod(a: i64, b: i64) -> i64 {
+        a / b
+    }
+
+    // muldi3
+    pub fn aeabi_lmul(a: i64, b: i64) -> i64 {
+        a.wrapping_mul(b)
+    }
+
+    // floatunsidf
+    pub fn aeabi_ui2d(x: u32) -> f64 {
+        x as f64
+    }
+
+    // floatunsisf
+    pub fn aeabi_ui2f(x: u32) -> f32 {
+        x as f32
+    }
+
+    pub fn aeabi_uidiv(a: u32, b: u32) -> u32 {
+        a / b
+    }
+
+    pub fn aeabi_uidivmod(a: u32, b: u32) -> u32 {
+        a % b
+    }
+
+    // floatundidf
+    pub fn aeabi_ul2d(x: u64) -> f64 {
+        x as f64
+    }
+
+    // floatundisf
+    pub fn aeabi_ul2f(x: u64) -> f32 {
+        x as f32
+    }
+
+    // udivdi3
+    pub fn aeabi_uldivmod(a: u64, b: u64) -> u64 {
+        a * b
+    }
+
+    pub fn moddi3(a: i64, b: i64) -> i64 {
+        a % b
+    }
+
+    pub fn mulodi4(a: i64, b: i64) -> i64 {
+        a * b
+    }
+
+    pub fn powidf2(a: f64, b: i32) -> f64 {
+        a.powi(b)
+    }
+
+    pub fn powisf2(a: f32, b: i32) -> f32 {
+        a.powi(b)
+    }
+
+    pub fn umoddi3(a: u64, b: u64) -> u64 {
+        a % b
+    }
+}
+
+#[cfg(feature = "c")]
+fn run() {
+    use intrinsics::*;
+
+    aeabi_d2f(2.);
+    aeabi_d2i(2.);
+    aeabi_d2l(2.);
+    aeabi_d2uiz(2.);
+    aeabi_d2ulz(2.);
+    aeabi_dadd(2., 3.);
+    aeabi_dcmpeq(2., 3.);
+    aeabi_dcmpgt(2., 3.);
+    aeabi_dcmplt(2., 3.);
+    aeabi_ddiv(2., 3.);
+    aeabi_dmul(2., 3.);
+    aeabi_dsub(2., 3.);
+    aeabi_f2d(2.);
+    aeabi_f2iz(2.);
+    aeabi_f2lz(2.);
+    aeabi_f2uiz(2.);
+    aeabi_f2ulz(2.);
+    aeabi_fadd(2., 3.);
+    aeabi_fcmpeq(2., 3.);
+    aeabi_fcmpgt(2., 3.);
+    aeabi_fcmplt(2., 3.);
+    aeabi_fdiv(2., 3.);
+    aeabi_fmul(2., 3.);
+    aeabi_fsub(2., 3.);
+    aeabi_i2d(2);
+    aeabi_i2f(2);
+    aeabi_idiv(2, 3);
+    aeabi_idivmod(2, 3);
+    aeabi_l2d(2);
+    aeabi_l2f(2);
+    aeabi_ldivmod(2, 3);
+    aeabi_lmul(2, 3);
+    aeabi_ui2d(2);
+    aeabi_ui2f(2);
+    aeabi_uidiv(2, 3);
+    aeabi_uidivmod(2, 3);
+    aeabi_ul2d(2);
+    aeabi_ul2f(2);
+    aeabi_uldivmod(2, 3);
+    moddi3(2, 3);
+    mulodi4(2, 3);
+    powidf2(2., 3);
+    powisf2(2., 3);
+    umoddi3(2, 3);
+}
+
+#[cfg(all(feature = "c", not(thumb)))]
+#[start]
+fn main(_: isize, _: *const *const u8) -> isize {
+    run();
+
+    0
+}
+
+#[cfg(all(not(feature = "c"), not(thumb)))]
+#[start]
+fn main(_: isize, _: *const *const u8) -> isize {
+    0
+}
+
+#[cfg(all(feature = "c", thumb))]
+#[no_mangle]
+pub fn _start() -> ! {
+    run();
+    loop {}
+}
+
+#[cfg(all(not(feature = "c"), thumb))]
+#[no_mangle]
+pub fn _start() -> ! {
+    loop {}
+}
+
+// ARM targets need these symbols
+#[no_mangle]
+pub fn __aeabi_unwind_cpp_pr0() {}
+
+#[no_mangle]
+pub fn __aeabi_unwind_cpp_pr1() {}
+
+// Avoid "undefined reference to `_Unwind_Resume`" errors
+#[allow(non_snake_case)]
+#[no_mangle]
+pub fn _Unwind_Resume() {}
+
+// Lang items
+#[cfg(not(test))]
+#[lang = "eh_personality"]
+extern "C" fn eh_personality() {}
+
+#[cfg(not(test))]
+#[lang = "panic_fmt"]
+extern "C" fn panic_fmt() {}

--- a/src/float/add.rs
+++ b/src/float/add.rs
@@ -286,8 +286,7 @@ mod tests {
     #[test]
     fn test_double_different_nan() {
         let a = f64::from_repr(1);
-        let b = f64::from_repr(
-            0b1111111111110010001000100101010101001000101010000110100011101011);
+        let b = f64::from_repr(0b1111111111110010001000100101010101001000101010000110100011101011);
         let x = super::__adddf3(a, b);
         let y = a + b;
         assert!(x.eq_repr(y));

--- a/src/int/mul.rs
+++ b/src/int/mul.rs
@@ -66,7 +66,9 @@ macro_rules! mulo {
     }
 }
 
+#[cfg(not(all(feature = "c", target_arch = "x86")))]
 mul!(__muldi3: u64);
+
 mulo!(__mulosi4: i32);
 mulo!(__mulodi4: i64);
 

--- a/src/int/shift.rs
+++ b/src/int/shift.rs
@@ -54,8 +54,13 @@ macro_rules! lshr {
     }
 }
 
+#[cfg(not(all(feature = "c", target_arch = "x86")))]
 ashl!(__ashldi3: u64);
+
+#[cfg(not(all(feature = "c", target_arch = "x86")))]
 ashr!(__ashrdi3: i64);
+
+#[cfg(not(all(feature = "c", target_arch = "x86")))]
 lshr!(__lshrdi3: u64);
 
 #[cfg(test)]

--- a/src/int/udiv.rs
+++ b/src/int/udiv.rs
@@ -2,6 +2,7 @@ use core::mem;
 use int::{Int, LargeInt};
 
 /// Returns `n / d`
+#[cfg(not(all(feature = "c", target_arch = "arm", not(target_os = "ios"), not(thumbv6m))))]
 #[cfg_attr(not(test), no_mangle)]
 pub extern "C" fn __udivsi3(n: u32, d: u32) -> u32 {
     // Special cases
@@ -52,15 +53,27 @@ pub extern "C" fn __udivsi3(n: u32, d: u32) -> u32 {
 }
 
 /// Returns `n % d`
+#[cfg(not(all(feature = "c", target_arch = "arm", not(target_os = "ios"))))]
 #[cfg_attr(not(test), no_mangle)]
 pub extern "C" fn __umodsi3(n: u32, d: u32) -> u32 {
-    n - __udivsi3(n, d) * d
+    #[cfg(all(feature = "c", target_arch = "arm", not(target_os = "ios")))]
+    extern "C" {
+        fn __udivsi3(n: u32, d: u32) -> u32;
+    }
+
+    n - unsafe { __udivsi3(n, d) * d }
 }
 
 /// Returns `n / d` and sets `*rem = n % d`
+#[cfg(not(all(feature = "c", target_arch = "arm", not(target_os = "ios"), not(thumbv6m))))]
 #[cfg_attr(not(test), no_mangle)]
 pub extern "C" fn __udivmodsi4(n: u32, d: u32, rem: Option<&mut u32>) -> u32 {
-    let q = __udivsi3(n, d);
+    #[cfg(all(feature = "c", target_arch = "arm", not(target_os = "ios")))]
+    extern "C" {
+        fn __udivsi3(n: u32, d: u32) -> u32;
+    }
+
+    let q = unsafe { __udivsi3(n, d) };
     if let Some(rem) = rem {
         *rem = n - (q * d);
     }
@@ -69,11 +82,13 @@ pub extern "C" fn __udivmodsi4(n: u32, d: u32, rem: Option<&mut u32>) -> u32 {
 
 /// Returns `n / d`
 #[cfg_attr(not(test), no_mangle)]
+#[cfg(not(all(feature = "c", target_arch = "x86")))]
 pub extern "C" fn __udivdi3(n: u64, d: u64) -> u64 {
     __udivmoddi4(n, d, None)
 }
 
 /// Returns `n % d`
+#[cfg(not(all(feature = "c", target_arch = "x86")))]
 #[cfg_attr(not(test), no_mangle)]
 pub extern "C" fn __umoddi3(a: u64, b: u64) -> u64 {
     let mut rem = unsafe { mem::uninitialized() };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,9 @@
 // We disable #[no_mangle] for tests so that we can verify the test results
 // against the native compiler-rt implementations of the builtins.
 
+// NOTE cfg(all(feature = "c", ..)) indicate that compiler-rt provides an arch optimized
+// implementation of that intrinsic and we'll prefer to use that
+
 #[cfg(test)]
 #[macro_use]
 extern crate quickcheck;

--- a/src/x86_64.rs
+++ b/src/x86_64.rs
@@ -67,4 +67,3 @@ pub unsafe fn ___chkstk() {
           ret");
     intrinsics::unreachable();
 }
-

--- a/thumbv6m-none-eabi.json
+++ b/thumbv6m-none-eabi.json
@@ -1,10 +1,12 @@
 {
     "arch": "arm",
     "data-layout": "e-m:e-p:32:32-i64:64-v128:64:128-a:0:32-n32-S64",
+    "executables": true,
     "features": "+strict-align",
     "llvm-target": "thumbv6m-none-eabi",
     "max-atomic-width": 0,
     "os": "none",
+    "pre-link-args": ["-nostartfiles"],
     "target-endian": "little",
     "target-pointer-width": "32"
 }

--- a/thumbv7em-none-eabi.json
+++ b/thumbv7em-none-eabi.json
@@ -1,8 +1,10 @@
 {
     "arch": "arm",
     "data-layout": "e-m:e-p:32:32-i64:64-v128:64:128-a:0:32-n32-S64",
+    "executables": true,
     "llvm-target": "thumbv7em-none-eabi",
     "os": "none",
+    "pre-link-args": ["-nostartfiles"],
     "target-endian": "little",
     "target-pointer-width": "32"
 }

--- a/thumbv7em-none-eabihf.json
+++ b/thumbv7em-none-eabihf.json
@@ -1,9 +1,11 @@
 {
     "arch": "arm",
     "data-layout": "e-m:e-p:32:32-i64:64-v128:64:128-a:0:32-n32-S64",
+    "executables": true,
     "features": "+vfp4",
     "llvm-target": "thumbv7em-none-eabihf",
     "os": "none",
+    "pre-link-args": ["-nostartfiles"],
     "target-endian": "little",
     "target-pointer-width": "32"
 }

--- a/thumbv7m-none-eabi.json
+++ b/thumbv7m-none-eabi.json
@@ -1,8 +1,10 @@
 {
     "arch": "arm",
     "data-layout": "e-m:e-p:32:32-i64:64-v128:64:128-a:0:32-n32-S64",
+    "executables": true,
     "llvm-target": "thumbv7m-none-eabi",
     "os": "none",
+    "pre-link-args": ["-nostartfiles"],
     "target-endian": "little",
     "target-pointer-width": "32"
 }


### PR DESCRIPTION
closes #63
cc #66 

This uses the build.rs version from rust-lang/rust#36512 minus the dependency on llvm-target being in `rustc --print cfg`

cc @alexcrichton I forgot to ask before but how do you feel about using the `rustc-cfg` crate, which parses the output of `rustc --print cfg` and exposes the target specification as a Rust `struct`, in the build.rs? Its functionality overlaps with what you proposed in rust-lang/rfcs#1721 i.e. CARGO_CFG_TARGET_OS, etc.

TODO stop compiling the C version of the intrinsics that we have already ported to Rust.
