### PR TITLE
cache Cargo artifacts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,8 +51,6 @@ script:
       cargo test --target $TARGET &&
       cargo test --target $TARGET --release;
     fi
-
-after_success:
   # Travis can't cache files that are not readable by "others"
   - chmod -R a+r /home/travis/.cargo
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ script:
       cargo test --target $TARGET --release;
     fi
   # Travis can't cache files that are not readable by "others"
-  - chmod -R a+r /home/travis/.cargo
+  - chmod -R a+r $HOME/.cargo
 
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+cache: cargo
 dist: trusty
 language: rust
 services: docker
@@ -45,13 +46,15 @@ install:
 script:
   - cargo generate-lockfile
   - if [[ $TRAVIS_OS_NAME = "linux" ]]; then
-      sudo apt-get remove -y qemu-user-static &&
-      sudo apt-get install -y qemu-user-static &&
       sh ci/run-docker.sh $TARGET;
     else
       cargo test --target $TARGET &&
       cargo test --target $TARGET --release;
     fi
+
+after_success:
+  # Travis can't cache files that are not readable by "others"
+  - chmod -R a+r /home/travis/.cargo
 
 branches:
   only:

--- a/ci/docker/aarch64-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/aarch64-unknown-linux-gnu/Dockerfile
@@ -5,6 +5,5 @@ RUN apt-get install -y --no-install-recommends \
   gcc-aarch64-linux-gnu libc6-dev-arm64-cross \
   qemu-user-static
 ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc \
-    PATH=$PATH:/rust/bin \
     QEMU_LD_PREFIX=/usr/aarch64-linux-gnu \
     RUST_TEST_THREADS=1

--- a/ci/docker/arm-unknown-linux-gnueabi/Dockerfile
+++ b/ci/docker/arm-unknown-linux-gnueabi/Dockerfile
@@ -4,7 +4,6 @@ RUN apt-get install -y --no-install-recommends \
   gcc libc6-dev ca-certificates \
   gcc-arm-linux-gnueabi libc6-dev-armel-cross qemu-user-static
 ENV CARGO_TARGET_ARM_UNKNOWN_LINUX_GNUEABI_LINKER=arm-linux-gnueabi-gcc \
-    PATH=$PATH:/rust/bin \
     QEMU_LD_PREFIX=/usr/arm-linux-gnueabi \
     RUST_TEST_THREADS=1
 

--- a/ci/docker/arm-unknown-linux-gnueabihf/Dockerfile
+++ b/ci/docker/arm-unknown-linux-gnueabihf/Dockerfile
@@ -4,6 +4,5 @@ RUN apt-get install -y --no-install-recommends \
   gcc libc6-dev ca-certificates \
   gcc-arm-linux-gnueabihf libc6-dev-armhf-cross qemu-user-static
 ENV CARGO_TARGET_ARM_UNKNOWN_LINUX_GNUEABIHF_LINKER=arm-linux-gnueabihf-gcc \
-    PATH=$PATH:/rust/bin \
     QEMU_LD_PREFIX=/usr/arm-linux-gnueabihf \
     RUST_TEST_THREADS=1

--- a/ci/docker/armv7-unknown-linux-gnueabihf/Dockerfile
+++ b/ci/docker/armv7-unknown-linux-gnueabihf/Dockerfile
@@ -4,6 +4,5 @@ RUN apt-get install -y --no-install-recommends \
   gcc libc6-dev ca-certificates \
   gcc-arm-linux-gnueabihf libc6-dev-armhf-cross qemu-user-static
 ENV CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_LINKER=arm-linux-gnueabihf-gcc \
-    PATH=$PATH:/rust/bin \
     QEMU_LD_PREFIX=/usr/arm-linux-gnueabihf \
     RUST_TEST_THREADS=1

--- a/ci/docker/i586-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/i586-unknown-linux-gnu/Dockerfile
@@ -2,4 +2,3 @@ FROM ubuntu:16.04
 RUN apt-get update
 RUN apt-get install -y --no-install-recommends \
   gcc-multilib libc6-dev ca-certificates
-ENV PATH=$PATH:/rust/bin

--- a/ci/docker/i686-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/i686-unknown-linux-gnu/Dockerfile
@@ -2,4 +2,3 @@ FROM ubuntu:16.04
 RUN apt-get update
 RUN apt-get install -y --no-install-recommends \
   gcc-multilib libc6-dev ca-certificates
-ENV PATH=$PATH:/rust/bin

--- a/ci/docker/mips-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/mips-unknown-linux-gnu/Dockerfile
@@ -7,6 +7,5 @@ RUN apt-get install -y --no-install-recommends \
         binfmt-support qemu-user-static qemu-system-mips
 
 ENV CARGO_TARGET_MIPS_UNKNOWN_LINUX_GNU_LINKER=mips-linux-gnu-gcc \
-    PATH=$PATH:/rust/bin \
     QEMU_LD_PREFIX=/usr/mips-linux-gnu \
     RUST_TEST_THREADS=1

--- a/ci/docker/mipsel-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/mipsel-unknown-linux-gnu/Dockerfile
@@ -7,6 +7,5 @@ RUN apt-get install -y --no-install-recommends \
         binfmt-support qemu-user-static
 
 ENV CARGO_TARGET_MIPSEL_UNKNOWN_LINUX_GNU_LINKER=mipsel-linux-gnu-gcc \
-    PATH=$PATH:/rust/bin \
     QEMU_LD_PREFIX=/usr/mipsel-linux-gnu \
     RUST_TEST_THREADS=1

--- a/ci/docker/powerpc-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/powerpc-unknown-linux-gnu/Dockerfile
@@ -7,6 +7,5 @@ RUN apt-get install -y --no-install-recommends \
         qemu-system-ppc
 
 ENV CARGO_TARGET_POWERPC_UNKNOWN_LINUX_GNU_LINKER=powerpc-linux-gnu-gcc \
-    PATH=$PATH:/rust/bin \
     QEMU_LD_PREFIX=/usr/powerpc-linux-gnu \
     RUST_TEST_THREADS=1

--- a/ci/docker/powerpc64-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/powerpc64-unknown-linux-gnu/Dockerfile
@@ -8,6 +8,5 @@ RUN apt-get install -y --no-install-recommends \
 
 ENV CARGO_TARGET_POWERPC64_UNKNOWN_LINUX_GNU_LINKER=powerpc64-linux-gnu-gcc \
     CC_powerpc64_unknown_linux_gnu=powerpc64-linux-gnu-gcc \
-    PATH=$PATH:/rust/bin \
     QEMU_LD_PREFIX=/usr/powerpc64-linux-gnu \
     RUST_TEST_THREADS=1

--- a/ci/docker/powerpc64le-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/powerpc64le-unknown-linux-gnu/Dockerfile
@@ -7,7 +7,5 @@ RUN apt-get install -y --no-install-recommends \
         qemu-system-ppc
 
 ENV CARGO_TARGET_POWERPC64LE_UNKNOWN_LINUX_GNU_LINKER=powerpc64le-linux-gnu-gcc \
-    CC_powerpc64le_unknown_linux_gnu=powerpc64le-linux-gnu-gcc \
-    PATH=$PATH:/rust/bin \
     QEMU_LD_PREFIX=/usr/powerpc64le-linux-gnu \
     RUST_TEST_THREADS=1

--- a/ci/docker/thumbv6m-none-eabi/Dockerfile
+++ b/ci/docker/thumbv6m-none-eabi/Dockerfile
@@ -5,4 +5,3 @@ RUN apt-get install -y --no-install-recommends \
 ENV AR_thumbv6m_none_eabi=arm-none-eabi-ar \
     CARGO_TARGET_THUMBV6M_NONE_EABI_LINKER=arm-none-eabi-gcc \
     CC_thumbv6m_none_eabi=arm-none-eabi-gcc \
-    PATH=$PATH:/rust/bin

--- a/ci/docker/thumbv7em-none-eabi/Dockerfile
+++ b/ci/docker/thumbv7em-none-eabi/Dockerfile
@@ -5,4 +5,3 @@ RUN apt-get install -y --no-install-recommends \
 ENV AR_thumbv7em_none_eabi=arm-none-eabi-ar \
     CARGO_TARGET_THUMBV7EM_NONE_EABI_LINKER=arm-none-eabi-gcc \
     CC_thumbv7em_none_eabi=arm-none-eabi-gcc \
-    PATH=$PATH:/rust/bin

--- a/ci/docker/thumbv7em-none-eabihf/Dockerfile
+++ b/ci/docker/thumbv7em-none-eabihf/Dockerfile
@@ -5,4 +5,3 @@ RUN apt-get install -y --no-install-recommends \
 ENV AR_thumbv7em_none_eabihf=arm-none-eabi-ar \
     CARGO_TARGET_THUMBV7EM_NONE_EABIHF_LINKER=arm-none-eabi-gcc \
     CC_thumbv7em_none_eabihf=arm-none-eabi-gcc \
-    PATH=$PATH:/rust/bin

--- a/ci/docker/thumbv7m-none-eabi/Dockerfile
+++ b/ci/docker/thumbv7m-none-eabi/Dockerfile
@@ -5,4 +5,3 @@ RUN apt-get install -y --no-install-recommends \
 ENV AR_thumbv7m_none_eabi=arm-none-eabi-ar \
     CARGO_TARGET_THUMBV7M_NONE_EABI_LINKER=arm-none-eabi-gcc \
     CC_thumbv7m_none_eabi=arm-none-eabi-gcc \
-    PATH=$PATH:/rust/bin

--- a/ci/docker/x86_64-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/x86_64-unknown-linux-gnu/Dockerfile
@@ -2,5 +2,3 @@ FROM ubuntu:16.04
 RUN apt-get update
 RUN apt-get install -y --no-install-recommends \
   gcc libc6-dev ca-certificates
-ENV PATH=$PATH:/rust/bin
-

--- a/ci/run-docker.sh
+++ b/ci/run-docker.sh
@@ -4,16 +4,18 @@
 set -ex
 
 run() {
-    local gid=$(id -g) \
-          group=$(id -g -n) \
-          target=$1 \
-          uid=$(id -u) \
-          user=$(id -u -n)
+    local target=$1
 
     echo $target
+
+    # This directory needs to exist before calling docker, otherwise docker will create it but it
+    # will be owned by root
+    mkdir -p target
+
     docker build -t $target ci/docker/$target
     docker run \
            --rm \
+           --user $(id -u):$(id -g) \
            -e CARGO_HOME=/cargo \
            -e CARGO_TARGET_DIR=/target \
            -v $HOME/.cargo:/cargo \
@@ -22,12 +24,7 @@ run() {
            -v `rustc --print sysroot`:/rust:ro \
            -w /checkout \
            -it $target \
-           sh -c "
-groupadd -g $gid $group
-useradd -m -g $gid -u $uid $user
-chown $user /cargo /target
-su -c 'PATH=\$PATH:/rust/bin ci/run.sh $target' $user
-"
+           sh -c "PATH=\$PATH:/rust/bin ci/run.sh $target"
 }
 
 if [ -z "$1" ]; then

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -44,10 +44,9 @@ esac
 
 case $TRAVIS_OS_NAME in
     osx)
-        NM=gnm
-
         # NOTE OSx's nm doesn't accept the `--defined-only` or provide an equivalent.
         # Use GNU nm instead
+        NM=gnm
         brew install binutils
         ;;
     *)
@@ -56,7 +55,7 @@ case $TRAVIS_OS_NAME in
 esac
 
 # NOTE On i586, It's normal that the get_pc_thunk symbol appears several times so ignore it
-$PREFIX$NM -g --defined-only /tmp/target/${1}/debug/librustc_builtins.rlib | \
+$PREFIX$NM -g --defined-only /target/${1}/debug/librustc_builtins.rlib | \
     sort | uniq -d | grep -v __x86.get_pc_thunk | grep 'T __'
 
 if test $? = 0; then


### PR DESCRIPTION
notable changes in the docker-based testing infrastructure

- the docker containers can now modify $CARGO_HOME, to re-use the outer
  Cargo registry, and the target directory to re-use build artifacts.

- the docker containers are removed when their execution finishes
  because it's no longer necessary to re-start them to inspect them
  because all the interesting output is in the outer target directory

r? @alexcrichton 

Let's see if this actually reduces test times ...