### PR TITLE
Initial implementation of multitester

### DIFF
--- a/src/float/add.rs
+++ b/src/float/add.rs
@@ -186,16 +186,13 @@ add!(__adddf3: f64);
 #[cfg(test)]
 mod tests {
     use core::{f32, f64};
+    use core::fmt;
 
     use float::Float;
     use qc::{U32, U64};
 
-    // NOTE The tests below have special handing for NaN values.
-    // Because NaN != NaN, the floating-point representations must be used
-    // Because there are many diffferent values of NaN, and the implementation
-    // doesn't care about calculating the 'correct' one, if both values are NaN
-    // the values are considered equivalent.
-
+    // TODO: Move this to F32/F64 in qc.rs
+    #[derive(Copy, Clone)]
     struct FRepr<F>(F);
 
     impl<F: Float> PartialEq for FRepr<F> {
@@ -209,6 +206,12 @@ mod tests {
                 return true
             }
             self.0.eq_repr(other.0)
+        }
+    }
+
+    impl<F: fmt::Debug> fmt::Debug for FRepr<F> {
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            self.0.fmt(f)
         }
     }
 


### PR DESCRIPTION
Implements part of #72.

I wanted to work on this first because it should help me find the problem in the add implementation.

Test failures now look like this:
```
__addsf3 - Args: 1 1264853201
  rustc-builtins: Some(0)
  compiler_rt:    Some(14950609)
  gcc_s:          None
__addsf3 - Args: 1 632426600
  rustc-builtins: Some(0)
  compiler_rt:    Some(0.00000000000000030889195)
  gcc_s:          None
__addsf3 - Args: 1 316213300
  rustc-builtins: Some(0)
  compiler_rt:    Some(0.0000000000000000000000000013696648)
  gcc_s:          None

[snip]

thread 'float::add::tests::_test::__addsf3' panicked at '[quickcheck] TEST FAILED. Arguments: (1, 1)', /home/matt/.cargo/registry/src/github.com-1ecc6299db9ec823/quickcheck-0.3.1/src/tester.rs:118
```

It currently prints all of the errors, if that's undesirable we'd need to remove the shrinkers or modify quickcheck.